### PR TITLE
fix: patching cluster rescale operation (#30)

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -111,7 +111,7 @@ jobs:
         with:
           images: ${{ secrets.REGISTRY_HOST }}/hallmaster/backend:latest
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/dev' }}
             type=sha,format=short
 
       - name: Build and push image (backend)

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fastify/compress": "8.3.1",
-    "@hallmaster/docker.js": "0.0.20",
+    "@hallmaster/docker.js": "0.0.21",
     "@hallmaster/prisma-client": "workspace:*",
     "@nestjs/common": "11.1.14",
     "@nestjs/config": "4.0.3",

--- a/packages/backend/src/clusters/dto/get-cluster-logs.dto.ts
+++ b/packages/backend/src/clusters/dto/get-cluster-logs.dto.ts
@@ -27,9 +27,17 @@ export class GetClusterLogsQueryZodDto extends createZodDto(
 
 export type GetClusterLogsQueryDto = z.infer<typeof GetClusterLogsQuerySchema>;
 
-export const GetClusterLogsSchema = z.object({
-  stderr: z.string(),
-  stdout: z.string(),
+export const GetClusterLogSchema = z.object({
+  content: z.string().meta({
+    description: 'The content of a log line.',
+  }),
+  stream: z.union([z.literal('STDOUT'), z.literal('STDERR')]).meta({
+    description: 'The stream that the log was published into.',
+  }),
+});
+
+export const GetClusterLogsSchema = z.array(GetClusterLogSchema).meta({
+  description: 'Logs (line by line) of a container.',
 });
 
 export class GetClusterLogsZodDto extends createZodDto(GetClusterLogsSchema) {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
         specifier: 8.3.1
         version: 8.3.1
       '@hallmaster/docker.js':
-        specifier: 0.0.20
-        version: 0.0.20
+        specifier: 0.0.21
+        version: 0.0.21
       '@hallmaster/prisma-client':
         specifier: workspace:*
         version: link:../prisma-client
@@ -772,8 +772,8 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@hallmaster/docker.js@0.0.20':
-    resolution: {integrity: sha512-GTi62iWhjkMYoQJbLRHxa1kvawqyRbygMskGkiLvdmAPoGSN+yp33GKAS/M90qCnAlx9Bef6Hp8Oty0C05nVsg==}
+  '@hallmaster/docker.js@0.0.21':
+    resolution: {integrity: sha512-hil9EqSHNJJ7kr9jJG9VFpYyO9VtBRl6sdTnmTGLAK0LLLqS7qrFt+7xd7pAtZSkVTAygyQSwBfJ0Lg0Bxnckg==}
 
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
@@ -5830,7 +5830,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hallmaster/docker.js@0.0.20': {}
+  '@hallmaster/docker.js@0.0.21': {}
 
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
update the dependency version from hallmaster/docker.js 0.0.20 to 0.0.21 to separate logs correctly from stdout and stderr streams.

---

## Checklist

* [X] My code follows the project's coding style
* [X] Tests pass locally
* [X] I added/updated relevant tests
* [X] I updated documentation (if needed)
* [X] This PR is ready for review
