### PR TITLE
fix(backend): returning status code `200` instead of `201` for `/auth/login`

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -38,6 +38,7 @@ export class AuthController {
   }
 
   @Post('login')
+  @HttpCode(HttpStatus.OK)
   @ApiOkResponse({
     type: UserTokenDto,
     description: 'The user token used to communicate with the API.',


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Conventionally, a POST returns a 201 by default; we change the status code to 200.

---

## Context / Motivation

N/A

---

## Related Links
https://docs.nestjs.com/controllers#status-code

---

## Screenshots (if applicable)

N/A

---

## Checklist

* [x] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

N/A