### PR TITLE
fix: bad docker image id when querying Prisma

### DIFF
--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -60,7 +60,7 @@ export class DockerService {
     }
 
     const dockerImage = await this.prismaService.dockerImage.findUnique({
-      where: { id: bot.id },
+      where: { id: bot.dockerImageId },
     });
     if (null === dockerImage) {
       throw new NotFoundException();


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
The wrong ID was given to the Prisma query when triyng to pull the Docker image.

## Checklist

* [X] My code follows the project's coding style
* [X] Tests pass locally
* [X] I added/updated relevant tests
* [X] I updated documentation (if needed)
* [X] This PR is ready for review
