### PR TITLE
feat(frontend-onboarding): adds deployment settings when creating bot

### DIFF
--- a/packages/frontend/src/lib/remotes/bot.remote.ts
+++ b/packages/frontend/src/lib/remotes/bot.remote.ts
@@ -1,11 +1,12 @@
 import { CreateBotSchema } from "@hallmaster/backend/dto";
 import { error, redirect } from "@sveltejs/kit";
 import { form, getRequestEvent } from "$app/server";
+import { API_URL } from "$env/static/private";
 
 export const createBot = form(CreateBotSchema, async (data) => {
   const token = getRequestEvent().cookies.get("token");
 
-  const response = await fetch(`/bot`, {
+  const response = await fetch(`${API_URL}/bot`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/packages/frontend/src/routes/(form)/setup/bot/components/Deployment.svelte
+++ b/packages/frontend/src/routes/(form)/setup/bot/components/Deployment.svelte
@@ -1,22 +1,63 @@
 <script lang="ts">
-import { BracesIcon, ContainerIcon } from "@lucide/svelte";
+import {
+  BracesIcon,
+  ContainerIcon,
+  RectangleEllipsisIcon,
+  TextCursorIcon,
+} from "@lucide/svelte";
+import { Switch } from "@skeletonlabs/skeleton-svelte";
 import LabeledInput from "$lib/components/LabeledInput.svelte";
+import { createBot } from "$lib/remotes/bot.remote";
+
+let checked: boolean = $state(false);
+
+const { dockerImage, token } = createBot.fields;
 </script>
 
 <div class="flex flex-col gap-4">
   <LabeledInput
     label="Container image url"
     icon={ContainerIcon}
-    type="url"
-    placeholder="https://ghcr.io/image:tag"
-    disabled
+    placeholder="ghcr.io/image:tag"
+    required
+    {...dockerImage.image.as("text")}
+    issues={dockerImage.image.issues()}
   />
+
+  <Switch {checked} onCheckedChange={(details) => (checked = details.checked)}>
+    <Switch.Control>
+      <Switch.Thumb />
+    </Switch.Control>
+    <Switch.Label>Registry authentication</Switch.Label>
+    <Switch.HiddenInput />
+  </Switch>
+
+  {#if checked}
+    <div class="flex gap-2">
+      <LabeledInput
+        label="Username"
+        icon={TextCursorIcon}
+        required
+        {...dockerImage.username.as("text")}
+        issues={dockerImage.username.issues()}
+      />
+
+      <LabeledInput
+        label="Password"
+        icon={RectangleEllipsisIcon}
+        required
+        {...dockerImage.password.as("password")}
+        issues={dockerImage.password.issues()}
+      />
+    </div>
+  {/if}
 
   <LabeledInput
     label="Bot token"
     icon={BracesIcon}
-    type="password"
     placeholder="8f0a2f30b4e738362ee19e8e572edb8a"
-    disabled
+    required
+    {...token.as("password")}
+    issues={token.issues()}
   />
 </div>


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
<!-- Example:
This PR fixes a bug in the authentication module and improves handling of expired tokens.
-->

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots
`/setup/bot`
<img width="480" height="551" alt="image" src="https://github.com/user-attachments/assets/eda5aaab-0285-435a-9edb-8e575b068143" />

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
