### PR TITLE
Fix/docker stats gathering

### DIFF
--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -167,6 +168,10 @@ export class ClustersController {
   })
   @ApiNotFoundResponse({
     description: 'The ID points to an unresolved cluster.',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'The requested cluster has no bound container or its not running.',
   })
   async getStats(@Param('id') id: UUID) {
     return await this.clustersService.stats(id);

--- a/packages/backend/src/clusters/clusters.service.ts
+++ b/packages/backend/src/clusters/clusters.service.ts
@@ -5,9 +5,9 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import type { Cluster } from '@hallmaster/prisma-client';
 import { DockerService } from '../docker/docker.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
-import type { Cluster } from '@hallmaster/prisma-client';
 
 @Injectable()
 export class ClustersService {
@@ -151,6 +151,12 @@ export class ClustersService {
 
     if (null === resource.containerId) {
       throw new BadRequestException('The cluster has no container ID.');
+    }
+
+    if (resource.status !== 'RUNNING') {
+      throw new BadRequestException(
+        'Unable to gather stats on a non-running cluster.',
+      );
     }
 
     return await this.dockerService.getContainerStats(resource.containerId);


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
In the current state, it is possible to request a cluster stats even on a non-running state, which makes no sense.

---

## Context / Motivation

Explain **why** this change is needed:
Not handling this behavior creates an InternalServerErrorException because `docker.js` returns a non-compliant object with the one expected when gathering facts.

---

## Checklist

* [X] My code follows the project's coding style
* [X] Tests pass locally
* [X] I added/updated relevant tests
* [X] I updated documentation (if needed)
* [X] This PR is ready for review
