### PR TITLE
feat(backend): stream cluster stat

### DIFF
--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -192,4 +192,25 @@ export class ClustersController {
   async getStats(@Param('id') id: UUID) {
     return await this.clustersService.stats(id);
   }
+
+  @Sse(':id/stats/stream')
+  @ApiOkResponse({
+    description:
+      'SSE stream that emits the stats of the cluster every 5 seconds.',
+    type: GetClusterStatsZodDto,
+  })
+  @ApiProduces('text/event-stream')
+  @ApiNotFoundResponse({
+    description: 'The ID points to an unresolved cluster.',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'The requested cluster has no bound container or its not running.',
+  })
+  streamStats(@Param('id') id: UUID): Observable<MessageEvent> {
+    return timer(0, 5000).pipe(
+      switchMap(() => from(this.clustersService.stats(id))),
+      switchMap((stats) => [{ data: stats } as MessageEvent]),
+    );
+  }
 }


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
This PR adds the SSE version of the `/clusters/:id/stats` route 

---

## Context / Motivation

Explain **why** this change is needed:
Prevents frontend from unnecessarily polling the API every X seconds to dynamically update the UI

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [ ] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
