### PR TITLE
fix(prisma): make DockerImage a child of Bot with cascade delete

### DIFF
--- a/packages/backend/prisma/migrations/20260403075738_docker_image_child_of_bot/migration.sql
+++ b/packages/backend/prisma/migrations/20260403075738_docker_image_child_of_bot/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `docker_image_id` on the `bot` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[bot_id]` on the table `docker_image` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `bot_id` to the `docker_image` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "bot" DROP CONSTRAINT "bot_docker_image_id_fkey";
+
+-- AlterTable
+ALTER TABLE "bot" DROP COLUMN "docker_image_id";
+
+-- AlterTable
+ALTER TABLE "docker_image" ADD COLUMN     "bot_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "docker_image_bot_id_key" ON "docker_image"("bot_id");
+
+-- AddForeignKey
+ALTER TABLE "docker_image" ADD CONSTRAINT "docker_image_bot_id_fkey" FOREIGN KEY ("bot_id") REFERENCES "bot"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -14,12 +14,11 @@ model User {
 }
 
 model Bot {
-  id            String      @id
-  token         String
-  totalShards   Int         @map("total_shards")
-  clusters      Cluster[]
-  dockerImage   DockerImage @relation(fields: [dockerImageId], references: [id])
-  dockerImageId String      @map("docker_image_id")
+  id          String       @id
+  token       String
+  totalShards Int          @map("total_shards")
+  clusters    Cluster[]
+  dockerImage DockerImage?
 
   @@map("bot")
 }
@@ -31,7 +30,8 @@ model DockerImage {
   tag        String  @default("latest")
   username   String?
   password   String?
-  bots       Bot[]
+  botId      String  @unique @map("bot_id")
+  bot        Bot     @relation(fields: [botId], references: [id], onDelete: Cascade)
 
   @@map("docker_image")
 }

--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -60,7 +60,7 @@ export class DockerService {
     }
 
     const dockerImage = await this.prismaService.dockerImage.findUnique({
-      where: { id: bot.dockerImageId },
+      where: { botId: bot.id },
     });
     if (null === dockerImage) {
       throw new NotFoundException();


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :

When deleting a bot and recreating one using the same docker registry `serverName`, a unique constraint violation was thrown.

The `DockerImage` row was never deleted because the relationship was inverted: `Bot` held the FK to `DockerImage`, making it the child. There was no way to cascade delete the image when the bot was removed.

So, we switch the relation: `DockerImage` now holds a `botId` FK pointing to `Bot` with a cascade delete
With this, a bot automatically delete its associated Docker image.

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

fixes #63 

---

## Screenshots (if applicable)
N/A

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes
N/A