### PR TITLE
refactor(backend): test behavior instead of implementation

### DIFF
--- a/packages/backend/src/bot/bot.service.spec.ts
+++ b/packages/backend/src/bot/bot.service.spec.ts
@@ -7,7 +7,6 @@ import { ClustersService } from '../clusters/clusters.service.js';
 import { CreateBotDto, UpdateBotDto } from 'src/index.dto.js';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/client';
 import { ConflictException, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@hallmaster/prisma-client';
 
 const HALLMASTER_BOT_ID = '1352006130926096504';
 const SHARDS_PER_CLUSTER = 3;
@@ -46,10 +45,6 @@ describe('BotService', () => {
     });
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-
   it('should create the bot', async () => {
     const body: CreateBotDto = {
       clusters: 1,
@@ -64,56 +59,16 @@ describe('BotService', () => {
 
     (prismaService.bot.create as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
-      totalShards: body.shards,
-      clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'STOPPED',
-          shardIds: [0],
-        },
-      ],
-    } satisfies Prisma.BotGetPayload<{
-      select: { id: true; totalShards: true; clusters: true };
-    }>);
+      totalShards: 1,
+      clusters: [{ id: '1', status: 'STOPPED', shardIds: [0] }],
+    });
 
     const result = await service.create(body);
 
-    const [serverName, ...path] = body.dockerImage.image.split('/');
-    const [image, tag] = path.join('/').split(':');
-    expect(prismaService.bot.create).toHaveBeenCalledWith({
-      data: {
-        id: HALLMASTER_BOT_ID,
-        token: body.token,
-        dockerImage: {
-          create: {
-            image: image,
-            serverName: serverName,
-            username: body.dockerImage.username,
-            password: body.dockerImage.password,
-            tag: tag,
-          },
-        },
-        totalShards: body.shards,
-        clusters: {
-          createMany: {
-            data: [{ status: 'STOPPED', shardIds: [0] }],
-          },
-        },
-      },
-      select: {
-        id: true,
-        clusters: true,
-        totalShards: true,
-      },
-    });
-    expect(prismaService.bot.create).toHaveBeenCalledTimes(1);
-
     expect(result).toStrictEqual({
       id: HALLMASTER_BOT_ID,
-      clusters: body.clusters,
-      shards: body.shards,
+      clusters: 1,
+      shards: 1,
     });
   });
 
@@ -131,74 +86,24 @@ describe('BotService', () => {
 
     (prismaService.bot.create as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
-      totalShards: body.shards,
+      totalShards: 7,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'RUNNING',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'RUNNING',
-          shardIds: [3, 4, 5],
-        },
-        {
-          id: '3',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-3`,
-          status: 'RUNNING',
-          shardIds: [6],
-        },
+        { id: '1', status: 'STOPPED', shardIds: [0, 1, 2] },
+        { id: '2', status: 'STOPPED', shardIds: [3, 4, 5] },
+        { id: '3', status: 'STOPPED', shardIds: [6] },
       ],
     });
 
     const result = await service.create(body);
 
-    expect(prismaService.bot.create).toHaveBeenCalledWith({
-      data: {
-        id: HALLMASTER_BOT_ID,
-        token: DISCORD_BOT_TOKEN,
-        dockerImage: {
-          create: {
-            image: 'hallmaster/discord-bot',
-            serverName: 'host.docker.internal:5000',
-            username: null,
-            password: null,
-            tag: 'latest',
-          },
-        },
-        totalShards: body.shards,
-        clusters: {
-          createMany: {
-            data: [
-              { status: 'STOPPED', shardIds: [0, 1, 2] },
-              { status: 'STOPPED', shardIds: [3, 4, 5] },
-              { status: 'STOPPED', shardIds: [6] },
-            ],
-          },
-        },
-      },
-      select: {
-        id: true,
-        totalShards: true,
-        clusters: true,
-      },
-    });
-    expect(prismaService.bot.create).toHaveBeenCalledTimes(1);
-
     expect(result).toStrictEqual({
       id: HALLMASTER_BOT_ID,
       clusters: 3,
-      shards: body.shards,
+      shards: 7,
     });
   });
 
-  it('should not create the bot', async () => {
+  it('should throw ConflictException when bot already exists', async () => {
     const body: CreateBotDto = {
       clusters: 1,
       shards: 1,
@@ -220,36 +125,6 @@ describe('BotService', () => {
     await expect(service.create(body)).rejects.toBeInstanceOf(
       ConflictException,
     );
-
-    const [serverName, ...path] = body.dockerImage.image.split('/');
-    const [image, tag] = path.join('/').split(':');
-    expect(prismaService.bot.create).toHaveBeenCalledWith({
-      data: {
-        id: HALLMASTER_BOT_ID,
-        token: body.token,
-        totalShards: body.shards,
-        dockerImage: {
-          create: {
-            image: image,
-            serverName: serverName,
-            username: body.dockerImage.username,
-            password: body.dockerImage.password,
-            tag: tag,
-          },
-        },
-        clusters: {
-          createMany: {
-            data: [{ status: 'STOPPED', shardIds: [0] }],
-          },
-        },
-      },
-      select: {
-        id: true,
-        clusters: true,
-        totalShards: true,
-      },
-    });
-    expect(prismaService.bot.create).toHaveBeenCalledTimes(1);
   });
 
   it('should find the bot', async () => {
@@ -257,35 +132,12 @@ describe('BotService', () => {
       id: HALLMASTER_BOT_ID,
       totalShards: 6,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'RUNNING',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'RUNNING',
-          shardIds: [3, 4, 5],
-        },
+        { id: '1', status: 'RUNNING', shardIds: [0, 1, 2] },
+        { id: '2', status: 'RUNNING', shardIds: [3, 4, 5] },
       ],
-    } satisfies Prisma.BotGetPayload<{
-      select: { id: true; totalShards: true; clusters: true };
-    }>);
+    });
 
     const data = await service.findOne();
-
-    expect(prismaService.bot.findFirst).toHaveBeenCalledWith({
-      select: {
-        id: true,
-        totalShards: true,
-        clusters: true,
-      },
-    });
-    expect(prismaService.bot.findFirst).toHaveBeenCalledTimes(1);
 
     expect(data).toStrictEqual({
       id: HALLMASTER_BOT_ID,
@@ -294,19 +146,10 @@ describe('BotService', () => {
     });
   });
 
-  it('should not find the bot', async () => {
+  it('should throw NotFoundException when no bot exists', async () => {
     prismaService.bot.findFirst.mockResolvedValueOnce(null);
 
     await expect(service.findOne()).rejects.toBeInstanceOf(NotFoundException);
-
-    expect(prismaService.bot.findFirst).toHaveBeenCalledWith({
-      select: {
-        id: true,
-        totalShards: true,
-        clusters: true,
-      },
-    });
-    expect(prismaService.bot.findFirst).toHaveBeenCalledTimes(1);
   });
 
   it('should update the bot clusters and shards (grow)', async () => {
@@ -319,121 +162,33 @@ describe('BotService', () => {
       id: HALLMASTER_BOT_ID,
       totalShards: 7,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'RUNNING',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'RUNNING',
-          shardIds: [3, 4, 5],
-        },
-        {
-          id: '3',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-3`,
-          status: 'RUNNING',
-          shardIds: [6],
-        },
+        { id: '1', status: 'RUNNING', shardIds: [0, 1, 2] },
+        { id: '2', status: 'RUNNING', shardIds: [3, 4, 5] },
+        { id: '3', status: 'RUNNING', shardIds: [6] },
       ],
-    } satisfies Prisma.BotGetPayload<{
-      select: { id: true; totalShards: true; clusters: true };
-    }>);
+    });
 
     clustersService.remove.mockResolvedValue();
 
     (prismaService.bot.update as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
-      totalShards: body.shards!,
+      totalShards: 10,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'UPDATING',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'UPDATING',
-          shardIds: [3, 4, 5],
-        },
-        {
-          id: '3',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-3`,
-          status: 'UPDATING',
-          shardIds: [6, 7, 8],
-        },
-        {
-          id: '4',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-4`,
-          status: 'UPDATING',
-          shardIds: [9],
-        },
+        { id: '1', status: 'UPDATING', shardIds: [0, 1, 2] },
+        { id: '2', status: 'UPDATING', shardIds: [3, 4, 5] },
+        { id: '3', status: 'UPDATING', shardIds: [6, 7, 8] },
+        { id: '4', status: 'UPDATING', shardIds: [9] },
       ],
-    } satisfies Prisma.BotGetPayload<{
-      select: { id: true; totalShards: true; clusters: true };
-    }>);
+    });
 
     clustersService.start.mockResolvedValue();
 
     const data = await service.update(body);
 
-    expect(prismaService.bot.findFirst).toHaveBeenCalledWith({
-      select: { clusters: true, id: true, totalShards: true },
-    });
-    expect(prismaService.bot.findFirst).toHaveBeenCalledTimes(1);
-
     expect(clustersService.remove).toHaveBeenCalledWith('1');
     expect(clustersService.remove).toHaveBeenCalledWith('2');
     expect(clustersService.remove).toHaveBeenCalledWith('3');
     expect(clustersService.remove).toHaveBeenCalledTimes(3);
-
-    expect(prismaService.bot.update).toHaveBeenCalledWith({
-      data: {
-        totalShards: body.shards,
-        clusters: {
-          createMany: {
-            data: [
-              {
-                status: 'UPDATING',
-                shardIds: [0, 1, 2],
-              },
-              {
-                status: 'UPDATING',
-                shardIds: [3, 4, 5],
-              },
-              {
-                status: 'UPDATING',
-                shardIds: [6, 7, 8],
-              },
-              {
-                status: 'UPDATING',
-                shardIds: [9],
-              },
-            ],
-          },
-        },
-      },
-      where: {
-        id: HALLMASTER_BOT_ID,
-      },
-      select: {
-        id: true,
-        totalShards: true,
-        clusters: true,
-      },
-    });
-    expect(prismaService.bot.update).toHaveBeenCalledTimes(1);
 
     expect(clustersService.start).toHaveBeenCalledWith('1');
     expect(clustersService.start).toHaveBeenCalledWith('2');
@@ -458,101 +213,28 @@ describe('BotService', () => {
       id: HALLMASTER_BOT_ID,
       totalShards: 7,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'STOPPED',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'RUNNING',
-          shardIds: [3, 4, 5],
-        },
-        {
-          id: '3',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-3`,
-          status: 'RUNNING',
-          shardIds: [6],
-        },
+        { id: '1', status: 'STOPPED', shardIds: [0, 1, 2] },
+        { id: '2', status: 'RUNNING', shardIds: [3, 4, 5] },
+        { id: '3', status: 'RUNNING', shardIds: [6] },
       ],
-    } satisfies Partial<
-      Prisma.BotGetPayload<{
-        select: { id: true; totalShards: true; clusters: true };
-      }>
-    >);
+    });
 
     clustersService.remove.mockResolvedValue();
 
     (prismaService.bot.update as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
-      totalShards: body.shards!,
+      totalShards: 5,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'STOPPED',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'RUNNING',
-          shardIds: [3, 4],
-        },
+        { id: '1', status: 'STOPPED', shardIds: [0, 1, 2] },
+        { id: '2', status: 'RUNNING', shardIds: [3, 4] },
       ],
-    } satisfies Prisma.BotGetPayload<{
-      select: { id: true; totalShards: true; clusters: true };
-    }>);
+    });
 
     clustersService.start.mockResolvedValue();
 
     const data = await service.update(body);
 
-    expect(prismaService.bot.findFirst).toHaveBeenCalledWith({
-      select: { clusters: true, id: true, totalShards: true },
-    });
-    expect(prismaService.bot.findFirst).toHaveBeenCalledTimes(1);
-
-    expect(clustersService.remove).toHaveBeenCalledWith('1');
-    expect(clustersService.remove).toHaveBeenCalledWith('2');
-    expect(clustersService.remove).toHaveBeenCalledWith('3');
     expect(clustersService.remove).toHaveBeenCalledTimes(3);
-
-    expect(prismaService.bot.update).toHaveBeenCalledWith({
-      data: {
-        totalShards: body.shards,
-        clusters: {
-          createMany: {
-            data: [
-              {
-                status: 'STOPPED',
-                shardIds: [0, 1, 2],
-              },
-              {
-                status: 'UPDATING',
-                shardIds: [3, 4],
-              },
-            ],
-          },
-        },
-      },
-      where: {
-        id: HALLMASTER_BOT_ID,
-      },
-      select: {
-        id: true,
-        totalShards: true,
-        clusters: true,
-      },
-    });
-    expect(prismaService.bot.update).toHaveBeenCalledTimes(1);
 
     expect(clustersService.start).toHaveBeenCalledWith('2');
     expect(clustersService.start).toHaveBeenCalledTimes(1);
@@ -564,7 +246,7 @@ describe('BotService', () => {
     });
   });
 
-  it('should not update the bot', async () => {
+  it('should throw NotFoundException when updating non-existent bot', async () => {
     const body: UpdateBotDto = {
       clusters: 2,
       shards: 5,
@@ -575,66 +257,23 @@ describe('BotService', () => {
     await expect(service.update(body)).rejects.toBeInstanceOf(
       NotFoundException,
     );
-
-    expect(prismaService.bot.findFirst).toHaveBeenCalledWith({
-      select: { clusters: true, id: true, totalShards: true },
-    });
-    expect(prismaService.bot.findFirst).toHaveBeenCalledTimes(1);
   });
 
-  it('should remove the bot', async () => {
+  it('should remove the bot and stop all clusters', async () => {
     (prismaService.bot.findFirst as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
       totalShards: 5,
       clusters: [
-        {
-          id: '1',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-1`,
-          status: 'STOPPED',
-          shardIds: [0, 1, 2],
-        },
-        {
-          id: '2',
-          botId: HALLMASTER_BOT_ID,
-          containerId: `${HALLMASTER_BOT_ID}-2`,
-          status: 'RUNNING',
-          shardIds: [3, 4],
-        },
+        { id: '1', status: 'STOPPED', shardIds: [0, 1, 2] },
+        { id: '2', status: 'RUNNING', shardIds: [3, 4] },
       ],
-    } satisfies Prisma.BotGetPayload<{
-      select: { id: true; totalShards: true; clusters: true };
-    }>);
+    });
 
-    prismaService.bot.delete.mockResolvedValueOnce(
-      {} as Prisma.BotGetPayload<object>,
-    );
-
+    prismaService.bot.delete.mockResolvedValueOnce({} as never);
     clustersService.stopByCluster.mockResolvedValue();
 
     const data = await service.remove();
 
-    expect(prismaService.bot.delete).toHaveBeenCalledWith({
-      where: {
-        id: HALLMASTER_BOT_ID,
-      },
-    });
-    expect(prismaService.bot.delete).toHaveBeenCalledTimes(1);
-
-    expect(clustersService.stopByCluster).toHaveBeenCalledWith({
-      id: '1',
-      botId: HALLMASTER_BOT_ID,
-      containerId: `${HALLMASTER_BOT_ID}-1`,
-      status: 'STOPPED',
-      shardIds: [0, 1, 2],
-    });
-    expect(clustersService.stopByCluster).toHaveBeenCalledWith({
-      id: '2',
-      botId: HALLMASTER_BOT_ID,
-      containerId: `${HALLMASTER_BOT_ID}-2`,
-      status: 'RUNNING',
-      shardIds: [3, 4],
-    });
     expect(clustersService.stopByCluster).toHaveBeenCalledTimes(2);
 
     expect(data).toStrictEqual({
@@ -644,14 +283,9 @@ describe('BotService', () => {
     });
   });
 
-  it('should not remove the bot', async () => {
+  it('should throw NotFoundException when removing non-existent bot', async () => {
     prismaService.bot.findFirst.mockResolvedValueOnce(null);
 
     await expect(service.remove()).rejects.toBeInstanceOf(NotFoundException);
-
-    expect(prismaService.bot.findFirst).toHaveBeenCalledWith({
-      select: { id: true, totalShards: true, clusters: true },
-    });
-    expect(prismaService.bot.findFirst).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Description

A good unit test should verify what the code does, not how it does it, for exemple : 
- Asserting on outputs return values and observable side effects (were the right clusters started/stopped?)
- Don't assert on internal wiring (what arguments were passed to the ORM)
- Tests must be resistant to refactoring (most important criterion for maintainability). If you can refactor the code without changing its behavior, no test should break
source: my architect, *Test Behavior, Not Implementation* (Google Blog)

The previous tests were asserting Prisma select clauses, data arguments, and call counts on every database method. Reordering keys in a select or tweaking a query would break the tests even though the service still does the same thing.

So, whats changed : 
- Removed all `toHaveBeenCalledWith` assertions on Prisma methods                                                                                                  
- Removed `satisfies Prisma.BotGetPayload<...>` type couplings                                                                                                 
- Simplified mock objects to only include fields the service actually uses                              
- Renamed tests to describe the expected behavior                                                                                                                                
- Kept assertions on business side effects

---

## Context / Motivation

Explain **why** this change is needed:
to avoid false positives, debt, and to maintain a stable and maintainable test suite over time

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
