### PR TITLE
fix(backend): persist token and dockerImage changes on `PATCH /bot`

### DIFF
--- a/packages/backend/src/bot/bot.service.ts
+++ b/packages/backend/src/bot/bot.service.ts
@@ -150,9 +150,53 @@ export class BotService {
     };
   }
 
+  private buildDockerImageUpdate(
+    input: UpdateBotZodDto['dockerImage'],
+    current: {
+      serverName: string;
+      image: string;
+      tag: string;
+      username: string | null;
+    } | null,
+  ): Record<string, unknown> | undefined {
+    if (!input) {
+      return undefined;
+    }
+
+    const update: Record<string, unknown> = {};
+
+    if (input.image !== undefined) {
+      const [serverName, ...path] = input.image.split('/');
+      const [image, tag] = path.join('/').split(':');
+      if (
+        current === null ||
+        serverName !== current.serverName ||
+        image !== current.image ||
+        tag !== current.tag
+      ) {
+        update.serverName = serverName;
+        update.image = image;
+        update.tag = tag;
+      }
+    }
+
+    if (input.username !== undefined && input.username !== current?.username) {
+      update.username = input.username;
+    }
+
+    if (input.password !== undefined) {
+      update.password = input.password;
+    }
+
+    return Object.keys(update).length > 0 ? update : undefined;
+  }
+
   async update(updateBotDto: UpdateBotZodDto): Promise<GetBotZodDto> {
     const bot = await this.prismaService.bot.findFirst({
-      select: BotService.BOT_SELECT,
+      select: {
+        ...BotService.BOT_SELECT,
+        token: true,
+      },
     });
 
     if (null === bot) {
@@ -171,6 +215,18 @@ export class BotService {
     const layoutChanged =
       JSON.stringify(sortedLayout) !== JSON.stringify(oldLayout);
 
+    const tokenChanged =
+      updateBotDto.token !== undefined && updateBotDto.token !== bot.token;
+
+    const dockerImageUpdate = this.buildDockerImageUpdate(
+      updateBotDto.dockerImage,
+      bot.dockerImage,
+    );
+    const dockerImageChanged = dockerImageUpdate !== undefined;
+
+    const shouldForceRestart =
+      layoutChanged || tokenChanged || dockerImageChanged;
+
     for (const cluster of bot.clusters) {
       await this.clustersService.remove(cluster.id as UUID);
     }
@@ -178,11 +234,15 @@ export class BotService {
     const newBot = await this.prismaService.bot.update({
       data: {
         totalShards,
+        ...(tokenChanged && { token: updateBotDto.token }),
+        ...(dockerImageChanged && {
+          dockerImage: { update: dockerImageUpdate },
+        }),
         clusters: {
           createMany: {
             data: layout.map((clusterShardIds, index) => ({
               status:
-                layoutChanged || bot.clusters[index]?.status !== 'STOPPED'
+                shouldForceRestart || bot.clusters[index]?.status !== 'STOPPED'
                   ? 'UPDATING'
                   : 'STOPPED',
               shardIds: clusterShardIds,

--- a/packages/backend/src/bot/dto/update-bot.dto.ts
+++ b/packages/backend/src/bot/dto/update-bot.dto.ts
@@ -1,11 +1,18 @@
 import { z } from 'zod';
 import { createZodDto } from 'nestjs-zod';
-import { CreateBotSchema } from './create-bot.dto.js';
+import {
+  CreateBotDockerImageSchema,
+  CreateBotSchema,
+} from './create-bot.dto.js';
 
 export const UpdateBotSchema = CreateBotSchema.extend({
   layout: z.array(z.array(z.number().nonnegative())).min(1).meta({
     description:
       'The cluster layout. Each element is an array of shard IDs assigned to that cluster. Example: [[0, 1, 2], [3]] creates 2 clusters with 4 total shards.',
+  }),
+  dockerImage: CreateBotDockerImageSchema.partial().meta({
+    description:
+      'Partial Docker image configuration. Any provided field will be updated.',
   }),
 }).partial();
 


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
This PR ensures that all fields sent in `PATCH /bot` are persisted.

---

## Context / Motivation

Explain **why** this change is needed:
Not all fields declared in the DTO were persisted.

---

## Related Links

Bug #70 

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
