### PR TITLE
ci(backend): pnpm cache, include workspace deps and watch prisma-client

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -6,9 +6,13 @@ on:
       - dev
     paths:
       - "packages/backend/**"
+      - "packages/prisma-client/**"
+      - ".github/workflows/backend-ci.yaml"
   pull_request:
     paths:
       - "packages/backend/**"
+      - "packages/prisma-client/**"
+      - ".github/workflows/backend-ci.yaml"
 
 concurrency:
   group: docker-build-${{ github.ref }}
@@ -30,9 +34,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --filter=@hallmaster/backend --frozen-lockfile
+        run: pnpm install --filter=@hallmaster/backend... --frozen-lockfile
 
       - name: Generate Prisma types
         run: pnpm --filter=@hallmaster/backend prisma:generate

--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -27,14 +27,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          cache: "pnpm"
+      - name: Setup Node.js & pnpm
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm install --filter=@hallmaster/backend... --frozen-lockfile


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
enables pnpm caching on setup-node
extends the install filter to include workspace dependencies
extends the trigger paths to also watch `prisma-client` and the workflow file itself

---

## Context / Motivation

Explain **why** this change is needed:
Install step was running from scratch on every CI run, and the filter without `...` was excluding workspace dependencies like `@hallmaster/prisma-client`, which could lead to inconsistent installs.
And before this PR a prisma schema change could silently skip the backend CI.

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [ ] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
