### PR TITLE
feat(backend): validate Discord token on POST/PATCH before persisting

### DIFF
--- a/packages/backend/src/bot/bot.service.spec.ts
+++ b/packages/backend/src/bot/bot.service.spec.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
@@ -27,13 +28,34 @@ const EXPECTED_DOCKER_IMAGE = {
   username: null,
 };
 
+const mockDiscordGatewayBotResponse = (status = 200, body: unknown = { shards: 1 }) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: () => Promise.resolve(body),
+  }) as Response;
+
 describe('BotService', () => {
   let service: BotService;
+  const originalFetch = globalThis.fetch;
+  const fetchMock = jest.fn<typeof fetch>();
 
   const prismaService: DeepMockProxy<PrismaService> = mockDeep<PrismaService>();
   const clustersService: DeepMockProxy<ClustersService> = mockDeep<ClustersService>();
 
+  beforeAll(() => {
+    globalThis.fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   beforeEach(async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(mockDiscordGatewayBotResponse());
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BotService,
@@ -90,6 +112,22 @@ describe('BotService', () => {
     );
 
     await expect(service.create(body)).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('should reject creation when Discord rejects the token', async () => {
+    const body: CreateBotDto = {
+      token: DISCORD_BOT_TOKEN,
+      dockerImage: {
+        image: 'host.docker.internal:5000/hallmaster/discord-bot:latest',
+        username: null,
+        password: null,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(mockDiscordGatewayBotResponse(401));
+
+    await expect(service.create(body)).rejects.toThrow('Invalid Discord bot token.');
+    expect(prismaService.bot.create).not.toHaveBeenCalled();
   });
 
   it('should find the bot', async () => {
@@ -331,6 +369,42 @@ describe('BotService', () => {
     prismaService.bot.findFirst.mockResolvedValueOnce(null);
 
     await expect(service.update(body)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('should reject update when Discord rejects the new token', async () => {
+    (prismaService.bot.findFirst as jest.Mock).mockResolvedValueOnce({
+      id: HALLMASTER_BOT_ID,
+      totalShards: 0,
+      clusters: [],
+      token: DISCORD_BOT_TOKEN,
+      dockerImage: MOCK_DOCKER_IMAGE,
+    });
+
+    fetchMock.mockResolvedValueOnce(mockDiscordGatewayBotResponse(401));
+
+    await expect(service.update({ token: 'a-new-but-invalid-token' })).rejects.toThrow('Invalid Discord bot token.');
+    expect(prismaService.bot.update).not.toHaveBeenCalled();
+  });
+
+  it('should not call Discord when the token is unchanged in update', async () => {
+    (prismaService.bot.findFirst as jest.Mock).mockResolvedValueOnce({
+      id: HALLMASTER_BOT_ID,
+      totalShards: 0,
+      clusters: [],
+      token: DISCORD_BOT_TOKEN,
+      dockerImage: MOCK_DOCKER_IMAGE,
+    });
+
+    (prismaService.bot.update as jest.Mock).mockResolvedValueOnce({
+      id: HALLMASTER_BOT_ID,
+      totalShards: 0,
+      clusters: [],
+      dockerImage: MOCK_DOCKER_IMAGE,
+    });
+
+    await service.update({ token: DISCORD_BOT_TOKEN });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('should remove the bot and stop all clusters', async () => {

--- a/packages/backend/src/bot/bot.service.ts
+++ b/packages/backend/src/bot/bot.service.ts
@@ -60,18 +60,10 @@ export class BotService {
     }
   }
 
-  async getRecommendedShards(): Promise<{ shards: number }> {
-    const bot = await this.prismaService.bot.findFirst({
-      select: { token: true },
-    });
-
-    if (bot === null) {
-      throw new NotFoundException('No bot created.');
-    }
-
+  private async fetchDiscordGatewayBot(token: string): Promise<{ shards: number }> {
     const response = await fetch('https://discord.com/api/v10/gateway/bot', {
       headers: {
-        Authorization: `Bot ${bot.token}`,
+        Authorization: `Bot ${token}`,
       },
     });
 
@@ -95,7 +87,21 @@ export class BotService {
     return { shards: data.shards };
   }
 
+  async getRecommendedShards(): Promise<{ shards: number }> {
+    const bot = await this.prismaService.bot.findFirst({
+      select: { token: true },
+    });
+
+    if (bot === null) {
+      throw new NotFoundException('No bot created.');
+    }
+
+    return await this.fetchDiscordGatewayBot(bot.token);
+  }
+
   async create(createBotDto: CreateBotZodDto): Promise<GetBotZodDto> {
+    await this.fetchDiscordGatewayBot(createBotDto.token);
+
     try {
       const [serverName, ...path] = createBotDto.dockerImage.image.split('/');
       const [image, tag] = path.join('/').split(':');
@@ -205,7 +211,12 @@ export class BotService {
     const oldLayout = bot.clusters.map((c) => [...c.shardIds].sort((a, b) => a - b));
     const layoutChanged = JSON.stringify(sortedLayout) !== JSON.stringify(oldLayout);
 
-    const tokenChanged = updateBotDto.token !== undefined && updateBotDto.token !== bot.token;
+    const newToken = updateBotDto.token !== undefined && updateBotDto.token !== bot.token ? updateBotDto.token : null;
+    const tokenChanged = newToken !== null;
+
+    if (newToken !== null) {
+      await this.fetchDiscordGatewayBot(newToken);
+    }
 
     const dockerImageUpdate = this.buildDockerImageUpdate(updateBotDto.dockerImage, bot.dockerImage);
     const dockerImageChanged = dockerImageUpdate !== undefined;
@@ -219,7 +230,7 @@ export class BotService {
     const newBot = await this.prismaService.bot.update({
       data: {
         totalShards,
-        ...(tokenChanged && { token: updateBotDto.token }),
+        ...(newToken !== null && { token: newToken }),
         ...(dockerImageChanged && {
           dockerImage: { update: dockerImageUpdate },
         }),


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Validates the Discord bot token with the Discord API before persisting anything on `POST /bot` and `PATCH /bot`.
On `PATCH`, the call only happens if the token actually changed.

---

## Context / Motivation

Explain **why** this change is needed:
Previously, we accepted any string as a Discord bot token and stored it in DB.
The first time we'd find out it was wrong was when a cluster tried to start and crashed. That meant invalid bots could sit in the database, frontends would receive "success" responses for inputs that would never work, and debugging was awkward.
Calling `/gateway/bot` with the token gives us an immediate yes/no from Discord, so we fail fast instead of pushing the problem downstream.

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
