### PR TITLE
feat(backend): expose Docker log timestamps in API responses

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fastify/compress": "8.3.1",
-    "@hallmaster/docker.js": "0.0.22",
+    "@hallmaster/docker.js": "0.0.27",
     "@hallmaster/prisma-client": "workspace:*",
     "@nestjs/common": "11.1.14",
     "@nestjs/config": "4.0.3",

--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -157,7 +157,7 @@ export class ClustersController {
         .then((s) => {
           stream = s;
 
-          stream.on('data', (log: { content: string; stream: string }) => {
+          stream.on('data', (log: { content: string; stream: string; timestamp?: string }) => {
             subscriber.next({ data: log } as MessageEvent);
           });
 

--- a/packages/backend/src/clusters/dto/get-cluster-logs.dto.ts
+++ b/packages/backend/src/clusters/dto/get-cluster-logs.dto.ts
@@ -24,6 +24,9 @@ export const GetClusterLogSchema = z.object({
   stream: z.union([z.literal('STDOUT'), z.literal('STDERR')]).meta({
     description: 'The stream that the log was published into.',
   }),
+  timestamp: z.string().optional().meta({
+    description: 'RFC3339Nano timestamp emitted by the Docker daemon for that log line.',
+  }),
 });
 
 export const GetClusterLogsSchema = z.array(GetClusterLogSchema).meta({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 8.3.1
         version: 8.3.1
       '@hallmaster/docker.js':
-        specifier: 0.0.22
-        version: 0.0.22
+        specifier: 0.0.27
+        version: 0.0.27
       '@hallmaster/prisma-client':
         specifier: workspace:*
         version: link:../prisma-client
@@ -880,8 +880,8 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@hallmaster/docker.js@0.0.22':
-    resolution: {integrity: sha512-RsJInc29qB29KPqGNiKFd2cVZYQfZz1oFdRsdL9SULPKj+gqLW2yQ2lzZsP5+1kT2FstoZVpZnwehEzxJUM3mw==}
+  '@hallmaster/docker.js@0.0.27':
+    resolution: {integrity: sha512-TLvtSDGK24qCPo/JrTyiZNFhgeEUU4wIYXS/rYNGZCCvIJ6NggC7htaexQYrUvdnt6Wf12jltqu1JjOksBNBNA==}
 
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
@@ -7436,7 +7436,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hallmaster/docker.js@0.0.22': {}
+  '@hallmaster/docker.js@0.0.27': {}
 
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Adds the `timestamp?: string` field to the `GetClusterLog` DTO and to the inline type used by the SSE stream handler in `ClustersController`.

---

## Context / Motivation

Explain **why** this change is needed:
Until the lib change, the Docker-emitted timestamp was glued to the start of `content`, which forced the UI to either always render it as part of the log line or strip it client-side.

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [ ] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
