### PR TITLE
fix(backend): only stream new logs on SSE, not the full history

### DIFF
--- a/packages/backend/src/clusters/clusters.service.ts
+++ b/packages/backend/src/clusters/clusters.service.ts
@@ -118,7 +118,7 @@ export class ClustersService {
     });
   }
 
-  async streamLogs(id: UUID, tail?: number | 'all'): Promise<Readable> {
+  async streamLogs(id: UUID, tail: number | 'all' = 0): Promise<Readable> {
     const resource = await this.getFullResource(id);
     if (null === resource.containerId) {
       throw new BadRequestException('The cluster has no container ID.');


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Changes the default `tail` on `ClustersService.streamLogs` from `undefined` to `0`, so the SSE endpoint `GET /clusters/:id/logs/stream` no longer replays the container's full log history before following.

The non-streaming endpoint `GET /clusters/:id/logs` is unmodified and still returns all logs by default.

---

## Context / Motivation

Explain **why** this change is needed:
For a real-time stream, the natural default is "from now on".
If a consumer needs history, that's what `GET /clusters/:id/logs` is for.

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
