### PR TITLE
feat(backend): allow configurable interval on SSE polling routes

### DIFF
--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -32,6 +32,7 @@ import { ClustersService } from './clusters.service.js';
 import { GetClusterLogsQueryZodDto, GetClusterLogsZodDto } from './dto/get-cluster-logs.dto.js';
 import { GetClusterStatsZodDto } from './dto/get-cluster-stats.dto.js';
 import { GetClusterZodDto } from './dto/get-cluster.dto.js';
+import { SseIntervalQueryZodDto } from './dto/sse-interval-query.dto.js';
 
 @ApiTags('Clusters')
 @Controller('clusters')
@@ -55,13 +56,13 @@ export class ClustersController {
 
   @Sse('stream')
   @ApiOkResponse({
-    description: 'SSE stream that emits the full list of clusters every 5 seconds.',
+    description: 'SSE stream that emits the full list of clusters at a configurable interval (default 5s).',
     type: GetClusterZodDto,
     isArray: true,
   })
   @ApiProduces('text/event-stream')
-  streamAll(): Observable<MessageEvent> {
-    return timer(0, 5000).pipe(
+  streamAll(@Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
+    return timer(0, query.interval * 1000).pipe(
       switchMap(() => from(this.clustersService.findAll())),
       switchMap((clusters) => [{ data: clusters } as MessageEvent]),
     );
@@ -189,7 +190,7 @@ export class ClustersController {
 
   @Sse(':id/stats/stream')
   @ApiOkResponse({
-    description: 'SSE stream that emits the stats of the cluster every 5 seconds.',
+    description: 'SSE stream that emits the stats of the cluster at a configurable interval (default 5s).',
     type: GetClusterStatsZodDto,
   })
   @ApiProduces('text/event-stream')
@@ -199,8 +200,8 @@ export class ClustersController {
   @ApiBadRequestResponse({
     description: 'The requested cluster has no bound container or its not running.',
   })
-  streamStats(@Param('id', ParseIntPipe) id: number): Observable<MessageEvent> {
-    return timer(0, 5000).pipe(
+  streamStats(@Param('id', ParseIntPipe) id: number, @Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
+    return timer(0, query.interval * 1000).pipe(
       switchMap(() => from(this.clustersService.stats(id))),
       switchMap((stats) => [{ data: stats } as MessageEvent]),
     );

--- a/packages/backend/src/clusters/dto/sse-interval-query.dto.ts
+++ b/packages/backend/src/clusters/dto/sse-interval-query.dto.ts
@@ -1,0 +1,10 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+export const SseIntervalQuerySchema = z.object({
+  interval: z.coerce.number().positive().min(1).max(120).optional().default(5).meta({
+    description: 'Refresh interval in seconds (1–120). Defaults to 5.',
+  }),
+});
+
+export class SseIntervalQueryZodDto extends createZodDto(SseIntervalQuerySchema) {}


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Adds an `?interval=N` query parameter (between 1-120, default to 5) to the two polling SSE routes: `GET /clusters/stream` and `GET /clusters/:id/stats/stream`

Log streaming route `GET /clusters/:id/logs/stream` is event-driven (it forwards Docker logs as they arrive), so no interval here.

---

## Context / Motivation

Explain **why** this change is needed:
Requested by @zowks :) 

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
