### PR TITLE
fix(backend): use `exhaustMap` for SSE timers routes

### DIFF
--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -24,7 +24,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { Observable, timer, switchMap, from } from 'rxjs';
+import { Observable, timer, exhaustMap, map, from } from 'rxjs';
 
 import { AuthGuard } from '../auth/guards/jwt.guard.js';
 
@@ -63,8 +63,8 @@ export class ClustersController {
   @ApiProduces('text/event-stream')
   streamAll(@Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
     return timer(0, query.interval * 1000).pipe(
-      switchMap(() => from(this.clustersService.findAll())),
-      switchMap((clusters) => [{ data: clusters } as MessageEvent]),
+      exhaustMap(() => from(this.clustersService.findAll())),
+      map((clusters) => ({ data: clusters }) as MessageEvent),
     );
   }
 
@@ -202,8 +202,8 @@ export class ClustersController {
   })
   streamStats(@Param('id', ParseIntPipe) id: number, @Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
     return timer(0, query.interval * 1000).pipe(
-      switchMap(() => from(this.clustersService.stats(id))),
-      switchMap((stats) => [{ data: stats } as MessageEvent]),
+      exhaustMap(() => from(this.clustersService.stats(id))),
+      map((stats) => ({ data: stats }) as MessageEvent),
     );
   }
 }


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
`switchMap` cancels the in-flight inner observable as soon as the next timer tick arrives. With interval=1s, if something takes more than 1s (slow query, ...) every tick cancels the previous request before it can emit, so the client never receives data.

`exhaustMap` instead drops new ticks while a call is still in flight

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [ ] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [ ] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
