### PR TITLE
feat(backend): stream returning stats for every running cluster

### DIFF
--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -29,6 +29,7 @@ import { Observable, timer, exhaustMap, map, from } from 'rxjs';
 import { AuthGuard } from '../auth/guards/jwt.guard.js';
 
 import { ClustersService } from './clusters.service.js';
+import { GetAggregateStatsZodDto } from './dto/get-aggregate-stats.dto.js';
 import { GetClusterLogsQueryZodDto, GetClusterLogsZodDto } from './dto/get-cluster-logs.dto.js';
 import { GetClusterStatsZodDto } from './dto/get-cluster-stats.dto.js';
 import { GetClusterZodDto } from './dto/get-cluster.dto.js';
@@ -65,6 +66,20 @@ export class ClustersController {
     return timer(0, query.interval * 1000).pipe(
       exhaustMap(() => from(this.clustersService.findAll())),
       map((clusters) => ({ data: clusters }) as MessageEvent),
+    );
+  }
+
+  @Sse('stats/stream')
+  @ApiOkResponse({
+    description:
+      'SSE stream that emits the stats of every running cluster at a configurable interval (default 5s). Clusters whose stats failed to fetch are omitted.',
+    type: GetAggregateStatsZodDto,
+  })
+  @ApiProduces('text/event-stream')
+  streamAggregateStats(@Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
+    return timer(0, query.interval * 1000).pipe(
+      exhaustMap(() => from(this.clustersService.aggregateStats())),
+      map((stats) => ({ data: stats }) as MessageEvent),
     );
   }
 

--- a/packages/backend/src/clusters/clusters.service.ts
+++ b/packages/backend/src/clusters/clusters.service.ts
@@ -6,6 +6,8 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { DockerService } from '../docker/docker.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
+import { GetAggregateStatsDto } from './dto/get-aggregate-stats.dto.js';
+
 @Injectable()
 export class ClustersService {
   constructor(
@@ -143,5 +145,30 @@ export class ClustersService {
     }
 
     return await this.dockerService.getContainerStats(resource.containerId);
+  }
+
+  async aggregateStats(): Promise<GetAggregateStatsDto> {
+    const clusters = await this.prismaService.cluster.findMany({
+      where: { status: 'RUNNING', containerId: { not: null } },
+      select: { id: true, containerId: true },
+    });
+
+    const runnable = clusters.filter((c): c is { id: number; containerId: string } => c.containerId !== null);
+
+    const results = await Promise.allSettled(
+      runnable.map(async (c) => ({
+        id: c.id,
+        stats: await this.dockerService.getContainerStats(c.containerId),
+      })),
+    );
+
+    const aggregate: GetAggregateStatsDto = {};
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        aggregate[result.value.id] = result.value.stats;
+      }
+    }
+
+    return aggregate;
   }
 }

--- a/packages/backend/src/clusters/dto/get-aggregate-stats.dto.ts
+++ b/packages/backend/src/clusters/dto/get-aggregate-stats.dto.ts
@@ -1,0 +1,12 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+import { GetClusterStatsSchema } from './get-cluster-stats.dto.js';
+
+export const GetAggregateStatsSchema = z.record(z.coerce.number().int().nonnegative(), GetClusterStatsSchema).meta({
+  description: 'Stats of every running cluster, keyed by cluster ID. Clusters whose stats failed to fetch are omitted.',
+});
+
+export class GetAggregateStatsZodDto extends createZodDto(GetAggregateStatsSchema) {}
+
+export type GetAggregateStatsDto = z.infer<typeof GetAggregateStatsSchema>;


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
This PR displays live CPU/memory across the whole bot in one SSE.

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
