### PR TITLE
fix: backend trim space from docker image

### DIFF
--- a/packages/backend/src/bot/bot.service.ts
+++ b/packages/backend/src/bot/bot.service.ts
@@ -29,7 +29,7 @@ export class BotService {
   ) {}
 
   private parseDockerImage(image: string): { serverName: string; image: string; tag: string } {
-    const [serverName, ...path] = image.split('/');
+    const [serverName, ...path] = image.trim().split('/');
     const [imageName, tag] = path.join('/').split(':');
     return { serverName, image: imageName, tag };
   }


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
This makes the backend trim the spaces from the docker image of the discord bot

---

## Context / Motivation

Explain **why** this change is needed:
If the docker image value contains an invalid character (mostly space is our concern), the docker daemon won't be able to pull it and this will cause a bug within the application

---

## Related Links

---

## Screenshots (if applicable)

---

## Checklist

* [X] My code follows the project's coding style
* [X] Tests pass locally
* [X] I added/updated relevant tests
* [X] I updated documentation (if needed)
* [X] This PR is ready for review

---

## Additional Notes
