### PR TITLE
fix(backend): make cluster lifecycle ops idempotent when container was removed out-of-band

### DIFF
--- a/packages/backend/src/docker/docker.service.spec.ts
+++ b/packages/backend/src/docker/docker.service.spec.ts
@@ -1,4 +1,5 @@
-import { DockerSocket } from '@hallmaster/docker.js';
+import { DockerAPIHttpError, DockerSocket } from '@hallmaster/docker.js';
+import type { Cluster } from '@hallmaster/prisma-client';
 import { ConfigService } from '@nestjs/config';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
@@ -11,11 +12,15 @@ import { DockerService } from './docker.service.js';
 
 describe('DockerService', () => {
   let service: DockerService;
-  const prismaService: DeepMockProxy<PrismaService> = mockDeep<PrismaService>();
-  const configService: DeepMockProxy<ConfigService> = mockDeep<ConfigService>();
-  const dockerSocket: DeepMockProxy<DockerSocket> = mockDeep<DockerSocket>();
+  let prismaService: DeepMockProxy<PrismaService>;
+  let configService: DeepMockProxy<ConfigService>;
+  let dockerSocket: DeepMockProxy<DockerSocket>;
 
   beforeEach(async () => {
+    prismaService = mockDeep<PrismaService>();
+    configService = mockDeep<ConfigService>();
+    dockerSocket = mockDeep<DockerSocket>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DockerService,
@@ -30,5 +35,37 @@ describe('DockerService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('idempotent lifecycle ops when container was removed out-of-band', () => {
+    const cluster: Cluster = {
+      botId: 'bot-1',
+      id: 0,
+      containerId: 'vanished-container-id',
+      shardIds: [0],
+      status: 'RUNNING',
+    };
+
+    it('stop() marks the cluster STOPPED and clears containerId instead of throwing', async () => {
+      dockerSocket.apiCall.mockRejectedValueOnce(new DockerAPIHttpError(404, 'no such container'));
+
+      await expect(service.stop(cluster)).resolves.not.toThrow();
+
+      expect(prismaService.cluster.update).toHaveBeenCalledWith({
+        where: { botId_id: { botId: 'bot-1', id: 0 } },
+        data: { status: 'STOPPED', containerId: null },
+      });
+    });
+
+    it('remove() deletes the DB row instead of throwing', async () => {
+      // First call inside stop(); second call inside remove(). Both 404.
+      dockerSocket.apiCall.mockRejectedValue(new DockerAPIHttpError(404, 'no such container'));
+
+      await expect(service.remove(cluster)).resolves.not.toThrow();
+
+      expect(prismaService.cluster.delete).toHaveBeenCalledWith({
+        where: { botId_id: { botId: 'bot-1', id: 0 } },
+      });
+    });
   });
 });

--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -16,6 +16,17 @@ export class DockerService {
     private readonly dockerSocket: DockerSocket,
   ) {}
 
+  private isContainerNotFound(error: unknown): boolean {
+    return error instanceof DockerAPIHttpError && error.status === 404;
+  }
+
+  private async clearContainerId(cluster: Cluster): Promise<void> {
+    await this.prismaService.cluster.update({
+      where: { botId_id: { botId: cluster.botId, id: cluster.id } },
+      data: { containerId: null },
+    });
+  }
+
   async verifyImage(dockerImage: {
     serverName: string;
     image: string;
@@ -102,6 +113,29 @@ export class DockerService {
 
     const dockerContainersAPI = new DockerContainersAPI(this.dockerSocket);
     let containerId: null | string = cluster.containerId;
+
+    // If we have a containerId in DB but Docker no longer knows about it
+    // (e.g. user removed it manually), clear the stale reference and fall
+    // through to the create path.
+    if (containerId !== null) {
+      try {
+        await dockerContainersAPI.get(containerId);
+      } catch (e) {
+        if (this.isContainerNotFound(e)) {
+          await this.clearContainerId(cluster);
+          containerId = null;
+        } else {
+          await this.prismaService.cluster.update({
+            where: { botId_id: { botId: bot.id, id: cluster.id } },
+            data: { status: 'ERROR' },
+          });
+          throw new BadRequestException('Unable to inspect the cluster container', {
+            description: `An error occurred while inspecting the Docker container: ${e instanceof Error ? e.message : String(e)}`,
+            cause: e,
+          });
+        }
+      }
+    }
 
     if (null === containerId) {
       await this.pullDockerImage(cluster, dockerImage);
@@ -192,13 +226,15 @@ export class DockerService {
     }
 
     const dockerContainersAPI = new DockerContainersAPI(this.dockerSocket);
+    let containerVanished = false;
 
     try {
-      const container = await dockerContainersAPI.get(cluster.containerId);
-
-      await dockerContainersAPI.stop(container.Id);
+      await dockerContainersAPI.stop(cluster.containerId);
     } catch (e) {
-      if (!(e instanceof DockerAPIHttpError) || e.message !== `no such container: ${cluster.containerId}`) {
+      if (this.isContainerNotFound(e)) {
+        // Container was removed out-of-band — treat stop as already done.
+        containerVanished = true;
+      } else {
         await this.prismaService.cluster.update({
           where: {
             botId_id: { botId: cluster.botId, id: cluster.id },
@@ -209,7 +245,7 @@ export class DockerService {
         });
 
         throw new BadRequestException('Unable to stop the cluster', {
-          description: `An error occurred while removing the Docker container: ${e instanceof Error ? e.message : String(e)}`,
+          description: `An error occurred while stopping the Docker container: ${e instanceof Error ? e.message : String(e)}`,
           cause: e,
         });
       }
@@ -221,6 +257,7 @@ export class DockerService {
       },
       data: {
         status: 'STOPPED',
+        ...(containerVanished && { containerId: null }),
       },
     });
   }
@@ -236,10 +273,13 @@ export class DockerService {
       try {
         await dockerContainersAPI.remove(cluster.containerId);
       } catch (e) {
-        throw new BadRequestException('Unable to remove the cluster', {
-          description: `An error occurred while removing the Docker container: ${e instanceof Error ? e.message : String(e)}`,
-          cause: e,
-        });
+        if (!this.isContainerNotFound(e)) {
+          throw new BadRequestException('Unable to remove the cluster', {
+            description: `An error occurred while removing the Docker container: ${e instanceof Error ? e.message : String(e)}`,
+            cause: e,
+          });
+        }
+        // Container already gone — proceed to delete the DB row.
       }
     }
 

--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -279,7 +279,6 @@ export class DockerService {
             cause: e,
           });
         }
-        // Container already gone — proceed to delete the DB row.
       }
     }
 


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Backend now tolerates clusters whose container was removed out-of-band (manually via docker rm, daemon restart, etc.) these were causing demo failures because every Docker call returned 404 and propagated up as a 400.

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
