### PR TITLE
fix(backend): recover from container name collisions on cluster start

### DIFF
--- a/packages/backend/src/docker/docker.service.spec.ts
+++ b/packages/backend/src/docker/docker.service.spec.ts
@@ -1,5 +1,5 @@
 import { DockerAPIHttpError, DockerSocket } from '@hallmaster/docker.js';
-import type { Cluster } from '@hallmaster/prisma-client';
+import type { Bot, Cluster } from '@hallmaster/prisma-client';
 import { ConfigService } from '@nestjs/config';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
@@ -66,6 +66,47 @@ describe('DockerService', () => {
       expect(prismaService.cluster.delete).toHaveBeenCalledWith({
         where: { botId_id: { botId: 'bot-1', id: 0 } },
       });
+    });
+  });
+
+  describe('start() with name collision', () => {
+    const bot: Bot = {
+      id: 'bot-1',
+      token: 'discord-token',
+      totalShards: 1,
+    } as unknown as Bot;
+
+    const cluster: Cluster = {
+      botId: 'bot-1',
+      id: 0,
+      containerId: null,
+      shardIds: [0],
+      status: 'STOPPED',
+    };
+
+    it('cleans up the stale container and retries when create returns 409', async () => {
+      configService.getOrThrow.mockReturnValue('ENV_NAME');
+      prismaService.dockerImage.findUnique.mockResolvedValue({
+        botId: 'bot-1',
+        serverName: 'docker.io',
+        image: 'foo/bar',
+        tag: 'latest',
+        username: null,
+        password: null,
+      });
+
+      // Image pull succeeds
+      // First create attempt fails with 409. Cleanup succeeds.
+      // Second create attempt succeeds. Then start succeeds.
+      dockerSocket.apiCall
+        .mockResolvedValueOnce(undefined) // pull
+        .mockRejectedValueOnce(new DockerAPIHttpError(409, 'name already in use')) // create #1
+        .mockResolvedValueOnce(undefined) // stop the stale one
+        .mockResolvedValueOnce(undefined) // remove the stale one
+        .mockResolvedValueOnce({ Id: 'new-container-id' } as never) // create #2
+        .mockResolvedValueOnce(undefined); // start
+
+      await expect(service.start(bot, cluster)).resolves.toBe('new-container-id');
     });
   });
 });

--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -1,6 +1,13 @@
 import type { Readable } from 'node:stream';
 
-import { DockerContainersAPI, DockerImagesAPI, DockerSocket, DockerAPIHttpError } from '@hallmaster/docker.js';
+import {
+  DockerContainersAPI,
+  DockerImagesAPI,
+  DockerSocket,
+  DockerAPIHttpError,
+  type DockerContainerCreated,
+  type DockerContainerCreationBody,
+} from '@hallmaster/docker.js';
 import { Bot, Cluster, DockerImage } from '@hallmaster/prisma-client';
 import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -16,8 +23,12 @@ export class DockerService {
     private readonly dockerSocket: DockerSocket,
   ) {}
 
+  private isDockerApiError(error: unknown, status: number): boolean {
+    return error instanceof DockerAPIHttpError && error.status === status;
+  }
+
   private isContainerNotFound(error: unknown): boolean {
-    return error instanceof DockerAPIHttpError && error.status === 404;
+    return this.isDockerApiError(error, 404);
   }
 
   private async clearContainerId(cluster: Cluster): Promise<void> {
@@ -25,6 +36,37 @@ export class DockerService {
       where: { botId_id: { botId: cluster.botId, id: cluster.id } },
       data: { containerId: null },
     });
+  }
+
+  private async cleanupStaleContainerByName(name: string): Promise<void> {
+    const api = new DockerContainersAPI(this.dockerSocket);
+
+    try {
+      await api.stop(name);
+    } catch {
+      // proceed to remove even if stop fails
+    }
+
+    try {
+      await api.remove(name);
+    } catch (e) {
+      // Any 404 is treated as success: the container is gone, which is the goal.
+      if (!this.isContainerNotFound(e)) throw e;
+    }
+  }
+
+  private async createContainerOrCleanup(
+    api: DockerContainersAPI,
+    body: Partial<DockerContainerCreationBody>,
+    name: string,
+  ): Promise<DockerContainerCreated> {
+    try {
+      return await api.create(body, name);
+    } catch (e) {
+      if (!this.isDockerApiError(e, 409)) throw e;
+      await this.cleanupStaleContainerByName(name);
+      return await api.create(body, name);
+    }
   }
 
   async verifyImage(dockerImage: {
@@ -140,7 +182,8 @@ export class DockerService {
     if (null === containerId) {
       await this.pullDockerImage(cluster, dockerImage);
       try {
-        const container = await dockerContainersAPI.create(
+        const container = await this.createContainerOrCleanup(
+          dockerContainersAPI,
           {
             Env: [
               `${discordBotTokenEnvName}=${bot.token}`,


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Backend now recovers from a name collision when creating a cluster's container. Previously, a stale container left behind by an external docker stop (without docker rm) or a previous incomplete teardown would block every subsequent `start()` with a 409 Conflict, and the user had to clean up manually with the Docker CLI.

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
