### PR TITLE
fix(backend-ci): docker file path

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -4,15 +4,14 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &backend-paths
+      - "docker/backend.Dockerfile"
+      - "secrets/backend/**"
       - "packages/backend/**"
       - "packages/prisma-client/**"
       - ".github/workflows/backend-ci.yaml"
   pull_request:
-    paths:
-      - "packages/backend/**"
-      - "packages/prisma-client/**"
-      - ".github/workflows/backend-ci.yaml"
+    paths: *backend-paths
 
 concurrency:
   group: docker-build-${{ github.ref }}
@@ -115,7 +114,7 @@ jobs:
         uses: docker/build-push-action@v6.19.2
         with:
           context: .
-          file: packages/backend/Dockerfile
+          file: docker/backend.Dockerfile
           push: true
           platforms: linux/amd64 #,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Fix the backend Dockerfile path in the GitHub Action CI file

---

## Context / Motivation

Explain **why** this change is needed:
The previous commit (https://github.com/HallMasterOrg/hallmaster/commit/c5fa52ca8cd8197d5d6a34a713541e5938cb8173) had changed the backend Dockerfile path, but the change was not mirrored in the CI manifest, leading to CI fails.

---

## Related Links

---

## Screenshots (if applicable)

---

## Checklist

* [X] My code follows the project's coding style
* [X] Tests pass locally
* [X] I added/updated relevant tests
* [X] I updated documentation (if needed)
* [X] This PR is ready for review

---

## Additional Notes
