### PR TITLE
feat(clusters): add bulk start/stop/restart routes for all clusters

### DIFF
--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -29,6 +29,7 @@ import { Observable, timer, exhaustMap, map, from } from 'rxjs';
 import { AuthGuard } from '../auth/guards/jwt.guard.js';
 
 import { ClustersService } from './clusters.service.js';
+import { ClusterBulkActionResultZodDto } from './dto/cluster-bulk-action-result.dto.js';
 import { GetAggregateStatsZodDto } from './dto/get-aggregate-stats.dto.js';
 import { GetClusterLogsQueryZodDto, GetClusterLogsZodDto } from './dto/get-cluster-logs.dto.js';
 import { GetClusterStatsZodDto } from './dto/get-cluster-stats.dto.js';
@@ -67,6 +68,39 @@ export class ClustersController {
       exhaustMap(() => from(this.clustersService.findAll())),
       map((clusters) => ({ data: clusters }) as MessageEvent),
     );
+  }
+
+  @Post('start')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({
+    type: ClusterBulkActionResultZodDto,
+    description:
+      'Start every cluster in parallel. Already-running clusters are no-ops. The response lists clusters that succeeded and those that failed, with the failure reason.',
+  })
+  async startAll() {
+    return await this.clustersService.startAll();
+  }
+
+  @Post('stop')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({
+    type: ClusterBulkActionResultZodDto,
+    description:
+      'Stop every cluster in parallel. Already-stopped clusters are no-ops. The response lists clusters that succeeded and those that failed, with the failure reason.',
+  })
+  async stopAll() {
+    return await this.clustersService.stopAll();
+  }
+
+  @Post('restart')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({
+    type: ClusterBulkActionResultZodDto,
+    description:
+      'Restart every cluster in parallel (stop + start). Stopped clusters are simply started. The response lists clusters that succeeded and those that failed, with the failure reason.',
+  })
+  async restartAll() {
+    return await this.clustersService.restartAll();
   }
 
   @Sse('stats/stream')

--- a/packages/backend/src/clusters/clusters.service.ts
+++ b/packages/backend/src/clusters/clusters.service.ts
@@ -6,6 +6,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { DockerService } from '../docker/docker.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
+import { ClusterBulkActionResultDto } from './dto/cluster-bulk-action-result.dto.js';
 import { GetAggregateStatsDto } from './dto/get-aggregate-stats.dto.js';
 
 @Injectable()
@@ -161,6 +162,42 @@ export class ClustersService {
     }
 
     return await this.dockerService.getContainerStats(resource.containerId);
+  }
+
+  async startAll(): Promise<ClusterBulkActionResultDto> {
+    return await this.runBulkAction((id) => this.start(id));
+  }
+
+  async stopAll(): Promise<ClusterBulkActionResultDto> {
+    return await this.runBulkAction((id) => this.stop(id));
+  }
+
+  async restartAll(): Promise<ClusterBulkActionResultDto> {
+    return await this.runBulkAction((id) => this.restart(id));
+  }
+
+  private async runBulkAction(action: (id: number) => Promise<unknown>): Promise<ClusterBulkActionResultDto> {
+    const clusters = await this.prismaService.cluster.findMany({
+      select: { id: true },
+      orderBy: { id: 'asc' },
+    });
+
+    const settled = await Promise.allSettled(clusters.map((c) => action(c.id)));
+
+    const succeeded: number[] = [];
+    const failed: Array<{ id: number; reason: string }> = [];
+
+    settled.forEach((result, index) => {
+      const id = clusters[index].id;
+      if (result.status === 'fulfilled') {
+        succeeded.push(id);
+      } else {
+        const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+        failed.push({ id, reason });
+      }
+    });
+
+    return { succeeded, failed };
   }
 
   async aggregateStats(): Promise<GetAggregateStatsDto> {

--- a/packages/backend/src/clusters/dto/cluster-bulk-action-result.dto.ts
+++ b/packages/backend/src/clusters/dto/cluster-bulk-action-result.dto.ts
@@ -1,0 +1,22 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+export const ClusterBulkActionResultSchema = z.object({
+  succeeded: z.array(z.number().int().nonnegative()).meta({
+    description: 'IDs of clusters where the action completed successfully.',
+  }),
+  failed: z
+    .array(
+      z.object({
+        id: z.number().int().nonnegative(),
+        reason: z.string(),
+      }),
+    )
+    .meta({
+      description: 'Clusters where the action failed, along with the failure reason.',
+    }),
+});
+
+export class ClusterBulkActionResultZodDto extends createZodDto(ClusterBulkActionResultSchema) {}
+
+export type ClusterBulkActionResultDto = z.infer<typeof ClusterBulkActionResultSchema>;


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Adds POST /clusters/start, POST /clusters/stop, POST /clusters/restart to operate on every cluster in one call

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
