### PR TITLE
feat(backend): stream cluster stats over SSE

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fastify/compress": "8.3.1",
-    "@hallmaster/docker.js": "0.0.27",
+    "@hallmaster/docker.js": "0.0.28",
     "@hallmaster/prisma-client": "workspace:*",
     "@nestjs/common": "11.1.14",
     "@nestjs/config": "4.0.3",

--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -111,10 +111,9 @@ export class ClustersController {
   })
   @ApiProduces('text/event-stream')
   streamAggregateStats(@Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
-    return timer(0, query.interval * 1000).pipe(
-      exhaustMap(() => from(this.clustersService.aggregateStats())),
-      map((stats) => ({ data: stats }) as MessageEvent),
-    );
+    return this.clustersService
+      .streamAggregateStats(query.interval)
+      .pipe(map((stats) => ({ data: stats }) as MessageEvent));
   }
 
   @Get(':id')
@@ -239,7 +238,8 @@ export class ClustersController {
 
   @Sse(':id/stats/stream')
   @ApiOkResponse({
-    description: 'SSE stream that emits the stats of the cluster at a configurable interval (default 5s).',
+    description:
+      'SSE stream that emits the stats of the cluster.',
     type: GetClusterStatsZodDto,
   })
   @ApiProduces('text/event-stream')
@@ -249,10 +249,24 @@ export class ClustersController {
   @ApiBadRequestResponse({
     description: 'The requested cluster has no bound container or its not running.',
   })
-  streamStats(@Param('id', ParseIntPipe) id: number, @Query() query: SseIntervalQueryZodDto): Observable<MessageEvent> {
-    return timer(0, query.interval * 1000).pipe(
-      exhaustMap(() => from(this.clustersService.stats(id))),
-      map((stats) => ({ data: stats }) as MessageEvent),
-    );
+  streamStats(@Param('id', ParseIntPipe) id: number): Observable<MessageEvent> {
+    return new Observable((subscriber) => {
+      let stream: Readable | undefined;
+
+      this.clustersService
+        .streamStats(id)
+        .then((s) => {
+          stream = s;
+
+          stream.on('data', (stats) => subscriber.next({ data: stats } as MessageEvent));
+          stream.on('end', () => subscriber.complete());
+          stream.on('error', (err) => subscriber.error(err));
+        })
+        .catch((err) => subscriber.error(err));
+
+      return () => {
+        stream?.destroy();
+      };
+    });
   }
 }

--- a/packages/backend/src/clusters/clusters.controller.ts
+++ b/packages/backend/src/clusters/clusters.controller.ts
@@ -32,7 +32,7 @@ import { ClustersService } from './clusters.service.js';
 import { ClusterBulkActionResultZodDto } from './dto/cluster-bulk-action-result.dto.js';
 import { GetAggregateStatsZodDto } from './dto/get-aggregate-stats.dto.js';
 import { GetClusterLogsQueryZodDto, GetClusterLogsZodDto } from './dto/get-cluster-logs.dto.js';
-import { GetClusterStatsZodDto } from './dto/get-cluster-stats.dto.js';
+import { GetClusterStatsDto, GetClusterStatsZodDto } from './dto/get-cluster-stats.dto.js';
 import { GetClusterZodDto } from './dto/get-cluster.dto.js';
 import { SseIntervalQueryZodDto } from './dto/sse-interval-query.dto.js';
 
@@ -238,8 +238,7 @@ export class ClustersController {
 
   @Sse(':id/stats/stream')
   @ApiOkResponse({
-    description:
-      'SSE stream that emits the stats of the cluster.',
+    description: 'SSE stream that emits the stats of the cluster.',
     type: GetClusterStatsZodDto,
   })
   @ApiProduces('text/event-stream')
@@ -258,7 +257,7 @@ export class ClustersController {
         .then((s) => {
           stream = s;
 
-          stream.on('data', (stats) => subscriber.next({ data: stats } as MessageEvent));
+          stream.on('data', (stats: GetClusterStatsDto) => subscriber.next({ data: stats } as MessageEvent));
           stream.on('end', () => subscriber.complete());
           stream.on('error', (err) => subscriber.error(err));
         })

--- a/packages/backend/src/clusters/clusters.service.ts
+++ b/packages/backend/src/clusters/clusters.service.ts
@@ -2,12 +2,14 @@ import type { Readable } from 'node:stream';
 
 import type { Cluster } from '@hallmaster/prisma-client';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Observable } from 'rxjs';
 
 import { DockerService } from '../docker/docker.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
 import { ClusterBulkActionResultDto } from './dto/cluster-bulk-action-result.dto.js';
 import { GetAggregateStatsDto } from './dto/get-aggregate-stats.dto.js';
+import { GetClusterStatsDto } from './dto/get-cluster-stats.dto.js';
 
 @Injectable()
 export class ClustersService {
@@ -164,6 +166,20 @@ export class ClustersService {
     return await this.dockerService.getContainerStats(resource.containerId);
   }
 
+  async streamStats(id: number): Promise<Readable> {
+    const resource = await this.getFullResource(id);
+
+    if (null === resource.containerId) {
+      throw new BadRequestException('The cluster has no container ID.');
+    }
+
+    if (resource.status !== 'RUNNING') {
+      throw new BadRequestException('Unable to gather stats on a non-running cluster.');
+    }
+
+    return await this.dockerService.streamContainerStats(resource.containerId);
+  }
+
   async startAll(): Promise<ClusterBulkActionResultDto> {
     return await this.runBulkAction((id) => this.start(id));
   }
@@ -223,5 +239,89 @@ export class ClustersService {
     }
 
     return aggregate;
+  }
+
+  streamAggregateStats(intervalSeconds: number): Observable<GetAggregateStatsDto> {
+    return new Observable<GetAggregateStatsDto>((subscriber) => {
+      const streams = new Map<number, Readable>();
+      const latest = new Map<number, GetClusterStatsDto>();
+      let closed = false;
+
+      const removeStream = (id: number) => {
+        streams.get(id)?.destroy();
+        streams.delete(id);
+        latest.delete(id);
+      };
+
+      const addStream = async (id: number, containerId: string) => {
+        if (streams.has(id)) {
+          return;
+        }
+
+        try {
+          const stream = await this.dockerService.streamContainerStats(containerId);
+
+          if (closed) {
+            stream.destroy();
+            return;
+          }
+
+          streams.set(id, stream);
+          stream.on('data', (stats: GetClusterStatsDto) => latest.set(id, stats));
+          stream.on('error', () => removeStream(id));
+          stream.on('end', () => removeStream(id));
+        } catch {
+        }
+      };
+
+      const reconcile = async () => {
+        let clusters: Array<{ id: number; containerId: string | null }>;
+        try {
+          clusters = await this.prismaService.cluster.findMany({
+            where: { status: 'RUNNING', containerId: { not: null } },
+            select: { id: true, containerId: true },
+          });
+        } catch {
+          return;
+        }
+
+        const running = new Map(
+          clusters
+            .filter((c): c is { id: number; containerId: string } => c.containerId !== null)
+            .map((c) => [c.id, c.containerId] as const),
+        );
+
+        for (const id of [...streams.keys()]) {
+          if (!running.has(id)) {
+            removeStream(id);
+          }
+        }
+
+        for (const [id, containerId] of running) {
+          void addStream(id, containerId);
+        }
+      };
+
+      const emit = () => {
+        const snapshot: GetAggregateStatsDto = {};
+        for (const [id, stats] of latest) {
+          snapshot[id] = stats;
+        }
+        subscriber.next(snapshot);
+      };
+
+      void reconcile();
+      const reconcileTimer = setInterval(() => void reconcile(), intervalSeconds * 1000);
+      const emitTimer = setInterval(emit, intervalSeconds * 1000);
+
+      return () => {
+        closed = true;
+        clearInterval(reconcileTimer);
+        clearInterval(emitTimer);
+        for (const id of [...streams.keys()]) {
+          removeStream(id);
+        }
+      };
+    });
   }
 }

--- a/packages/backend/src/clusters/clusters.service.ts
+++ b/packages/backend/src/clusters/clusters.service.ts
@@ -271,6 +271,7 @@ export class ClustersService {
           stream.on('error', () => removeStream(id));
           stream.on('end', () => removeStream(id));
         } catch {
+          // the next reconcile tick will retry opening this stream
         }
       };
 

--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -1,4 +1,4 @@
-import type { Readable } from 'node:stream';
+import { Readable, Transform } from 'node:stream';
 
 import {
   DockerContainersAPI,
@@ -7,6 +7,7 @@ import {
   DockerAPIHttpError,
   type DockerContainerCreated,
   type DockerContainerCreationBody,
+  type DockerContainerStats,
 } from '@hallmaster/docker.js';
 import { Bot, Cluster, ClusterStatus, DockerImage } from '@hallmaster/prisma-client';
 import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
@@ -415,6 +416,33 @@ export class DockerService {
       stream: false,
     });
 
+    return DockerService.toStatsDto(stats);
+  }
+
+  async streamContainerStats(id: string): Promise<Readable> {
+    const dockerContainersAPI = new DockerContainersAPI(this.dockerSocket);
+
+    const raw = await dockerContainersAPI.stats(id, { stream: true });
+
+    const transform = new Transform({
+      objectMode: true,
+      transform(stats: DockerContainerStats, _encoding, callback) {
+        if (stats.precpu_stats.system_cpu_usage === 0) {
+          callback();
+          return;
+        }
+
+        callback(null, DockerService.toStatsDto(stats));
+      },
+    });
+
+    raw.pipe(transform);
+    raw.on('error', (err) => transform.destroy(err));
+
+    return transform;
+  }
+
+  private static toStatsDto(stats: DockerContainerStats): GetClusterStatsZodDto {
     const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - stats.precpu_stats.cpu_usage.total_usage;
 
     const systemDelta = stats.cpu_stats.system_cpu_usage - stats.precpu_stats.system_cpu_usage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 8.3.1
         version: 8.3.1
       '@hallmaster/docker.js':
-        specifier: 0.0.27
-        version: 0.0.27
+        specifier: 0.0.28
+        version: 0.0.28
       '@hallmaster/prisma-client':
         specifier: workspace:*
         version: link:../prisma-client
@@ -901,8 +901,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hallmaster/docker.js@0.0.27':
-    resolution: {integrity: sha512-TLvtSDGK24qCPo/JrTyiZNFhgeEUU4wIYXS/rYNGZCCvIJ6NggC7htaexQYrUvdnt6Wf12jltqu1JjOksBNBNA==}
+  '@hallmaster/docker.js@0.0.28':
+    resolution: {integrity: sha512-Nu3dALGsn3o6k4vcX7IRgFU/BXtZ+JZlBxEYuu2lbdaEoKL6Pu/Hq8BT3urSIVbl3usXNleXbiaHyCLCGxtJUA==}
 
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
@@ -7566,7 +7566,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hallmaster/docker.js@0.0.27': {}
+  '@hallmaster/docker.js@0.0.28': {}
 
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :

Reworks the cluster stats SSE routes to consume Docker's native stats stream instead of polling.

- `GET /clusters/:id/stats/stream` now holds a single persistent Docker stats stream and forwards each sample as it arrives, instead of re-requesting stats on a timer. Interval query param is dropped for this route (Docker drives the cadence).

- `GET /clusters/stats/stream` keeps one persistent stats stream open per running container, caches the latest sample per cluster, and emits the merged snapshot every N seconds. Clusters changes (started/stopped) is reconciled on the same cadence, and streams that end on their own are dropped.

- Bumps `@hallmaster/docker.js` to `0.0.28` (the version exposing the streaming overload).

---

## Context / Motivation

Explain **why** this change is needed:

The stats SSE routes polled Docker with `stream=false` on a timer. In that mode Docker "waits for 2 cycles" to compute the CPU delta before returning a single sample and disconnecting.
With `exhaustMap`, whenever a cycle overran the interval the following ticks were dropped, so at short intervals (e.g. 1s over several containers) the daemon couldn't keep up and the SSE cadence became erratic.

---

## Related Links

https://github.com/HallMasterOrg/docker.js/pull/20

---

## Screenshots (if applicable)

N/A, video too big

---

## Checklist

* [x] My code follows the project's coding style
* [ ] Tests pass locally
* [ ] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
