### PR TITLE
feat(backend): expose bot Discord profile on `GET /bot`

### DIFF
--- a/packages/backend/src/bot/bot.module.ts
+++ b/packages/backend/src/bot/bot.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module.js';
 import { ClustersModule } from '../clusters/clusters.module.js';
+import { DiscordModule } from '../discord/discord.module.js';
 import { DockerModule } from '../docker/docker.module.js';
 import { PrismaModule } from '../prisma/prisma.module.js';
 
@@ -9,7 +10,7 @@ import { BotController } from './bot.controller.js';
 import { BotService } from './bot.service.js';
 
 @Module({
-  imports: [AuthModule, PrismaModule, ClustersModule, DockerModule],
+  imports: [AuthModule, PrismaModule, ClustersModule, DockerModule, DiscordModule],
   controllers: [BotController],
   providers: [BotService],
 })

--- a/packages/backend/src/bot/bot.service.spec.ts
+++ b/packages/backend/src/bot/bot.service.spec.ts
@@ -7,6 +7,7 @@ import type { DeepMockProxy } from 'jest-mock-extended';
 import { mockDeep } from 'jest-mock-extended';
 
 import { ClustersService } from '../clusters/clusters.service.js';
+import { DiscordService } from '../discord/discord.service.js';
 import { DockerService } from '../docker/docker.service.js';
 import type { CreateBotDto, UpdateBotDto } from '../index.dto.js';
 import { PrismaService } from '../prisma/prisma.service.js';
@@ -36,6 +37,28 @@ const mockDiscordGatewayBotResponse = (status = 200, body: unknown = { shards: 1
     json: () => Promise.resolve(body),
   }) as Response;
 
+const DISCORD_USER = {
+  id: HALLMASTER_BOT_ID,
+  username: 'HallMaster',
+  global_name: 'HallMaster Bot',
+  discriminator: '0',
+  avatar: 'abc123',
+  banner: 'a_def456',
+  accent_color: 5793266,
+};
+
+const EXPECTED_DISCORD_PROFILE = {
+  name: 'HallMaster',
+  displayName: 'HallMaster Bot',
+  discriminator: '0',
+  avatarUrl: `https://cdn.discordapp.com/avatars/${HALLMASTER_BOT_ID}/abc123.png`,
+  bannerUrl: `https://cdn.discordapp.com/banners/${HALLMASTER_BOT_ID}/a_def456.gif`,
+  accentColor: 5793266,
+};
+
+const mockDiscordUserResponse = (body: unknown = DISCORD_USER) =>
+  ({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body) }) as Response;
+
 describe('BotService', () => {
   let service: BotService;
   const originalFetch = globalThis.fetch;
@@ -64,6 +87,7 @@ describe('BotService', () => {
         { provide: PrismaService, useValue: prismaService },
         { provide: ClustersService, useValue: clustersService },
         { provide: DockerService, useValue: dockerService },
+        DiscordService,
       ],
     }).compile();
 
@@ -149,16 +173,18 @@ describe('BotService', () => {
     expect(prismaService.bot.create).not.toHaveBeenCalled();
   });
 
-  it('should find the bot', async () => {
+  it('should find the bot with its Discord profile', async () => {
     (prismaService.bot.findFirst as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
       totalShards: 6,
+      token: DISCORD_BOT_TOKEN,
       clusters: [
         { id: 0, status: 'RUNNING', shardIds: [0, 1, 2] },
         { id: 1, status: 'RUNNING', shardIds: [3, 4, 5] },
       ],
       dockerImage: MOCK_DOCKER_IMAGE,
     });
+    fetchMock.mockResolvedValueOnce(mockDiscordUserResponse());
 
     const data = await service.findOne();
 
@@ -170,6 +196,7 @@ describe('BotService', () => {
         { id: 1, shardIds: [3, 4, 5] },
       ],
       dockerImage: EXPECTED_DOCKER_IMAGE,
+      discord: EXPECTED_DISCORD_PROFILE,
     });
   });
 
@@ -177,9 +204,11 @@ describe('BotService', () => {
     (prismaService.bot.findFirst as jest.Mock).mockResolvedValueOnce({
       id: HALLMASTER_BOT_ID,
       totalShards: 0,
+      token: DISCORD_BOT_TOKEN,
       clusters: [],
       dockerImage: MOCK_DOCKER_IMAGE,
     });
+    fetchMock.mockResolvedValueOnce(mockDiscordUserResponse());
 
     const data = await service.findOne();
 
@@ -188,7 +217,23 @@ describe('BotService', () => {
       shards: 0,
       layout: [],
       dockerImage: EXPECTED_DOCKER_IMAGE,
+      discord: EXPECTED_DISCORD_PROFILE,
     });
+  });
+
+  it('should return a null Discord profile when Discord is unreachable', async () => {
+    (prismaService.bot.findFirst as jest.Mock).mockResolvedValueOnce({
+      id: HALLMASTER_BOT_ID,
+      totalShards: 0,
+      token: DISCORD_BOT_TOKEN,
+      clusters: [],
+      dockerImage: MOCK_DOCKER_IMAGE,
+    });
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+    const data = await service.findOne();
+
+    expect(data.discord).toBeNull();
   });
 
   it('should throw NotFoundException when no bot exists', async () => {

--- a/packages/backend/src/bot/bot.service.ts
+++ b/packages/backend/src/bot/bot.service.ts
@@ -1,15 +1,8 @@
-import {
-  BadRequestException,
-  ConflictException,
-  HttpException,
-  HttpStatus,
-  Injectable,
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/client';
 
 import { ClustersService } from '../clusters/clusters.service.js';
+import { DiscordService, type DiscordProfile } from '../discord/discord.service.js';
 import { DockerService } from '../docker/docker.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
@@ -26,6 +19,7 @@ export class BotService {
     private readonly prismaService: PrismaService,
     private readonly clustersService: ClustersService,
     private readonly dockerService: DockerService,
+    private readonly discordService: DiscordService,
   ) {}
 
   private parseDockerImage(image: string): { serverName: string; image: string; tag: string } {
@@ -104,31 +98,12 @@ export class BotService {
     });
   }
 
-  private async fetchDiscordGatewayBot(token: string): Promise<{ shards: number }> {
-    const response = await fetch('https://discord.com/api/v10/gateway/bot', {
-      headers: {
-        Authorization: `Bot ${token}`,
-      },
-    });
-
-    if (response.status === 401) {
-      throw new UnauthorizedException('Invalid Discord bot token.');
+  private async fetchDiscordProfile(token: string): Promise<DiscordProfile | null> {
+    try {
+      return await this.discordService.getCurrentUser(token);
+    } catch {
+      return null;
     }
-
-    if (!response.ok) {
-      throw new HttpException(
-        `Discord API returned ${response.status}: ${response.statusText}`,
-        HttpStatus.FAILED_DEPENDENCY,
-      );
-    }
-
-    const data = (await response.json()) as { shards?: number };
-
-    if (!data.shards || typeof data.shards !== 'number') {
-      throw new HttpException('Got an invalid response from the Discord API.', HttpStatus.FAILED_DEPENDENCY);
-    }
-
-    return { shards: data.shards };
   }
 
   async getRecommendedShards(): Promise<{ shards: number }> {
@@ -140,11 +115,11 @@ export class BotService {
       throw new NotFoundException('No bot created.');
     }
 
-    return await this.fetchDiscordGatewayBot(bot.token);
+    return await this.discordService.getGatewayBot(bot.token);
   }
 
   async create(createBotDto: CreateBotZodDto): Promise<GetBotZodDto> {
-    await this.fetchDiscordGatewayBot(createBotDto.token);
+    await this.discordService.getGatewayBot(createBotDto.token);
 
     const { serverName, image, tag } = this.parseDockerImage(createBotDto.dockerImage.image);
 
@@ -191,7 +166,7 @@ export class BotService {
 
   async findOne(): Promise<GetBotZodDto> {
     const bot = await this.prismaService.bot.findFirst({
-      select: BotService.BOT_SELECT,
+      select: { ...BotService.BOT_SELECT, token: true },
     });
 
     if (null === bot) {
@@ -203,6 +178,7 @@ export class BotService {
       shards: bot.totalShards,
       layout: bot.clusters.map((c) => ({ id: c.id, shardIds: c.shardIds })),
       dockerImage: formatDockerImage(bot.dockerImage),
+      discord: await this.fetchDiscordProfile(bot.token),
     };
   }
 
@@ -289,7 +265,7 @@ export class BotService {
     const tokenChanged = newToken !== null;
 
     if (newToken !== null) {
-      await this.fetchDiscordGatewayBot(newToken);
+      await this.discordService.getGatewayBot(newToken);
     }
 
     const dockerImageUpdate = this.buildDockerImageUpdate(updateBotDto.dockerImage, bot.dockerImage);

--- a/packages/backend/src/bot/dto/get-bot.dto.ts
+++ b/packages/backend/src/bot/dto/get-bot.dto.ts
@@ -19,6 +19,27 @@ export const GetBotLayoutClusterSchema = z.object({
   }),
 });
 
+export const GetBotDiscordSchema = z.object({
+  name: z.string().meta({
+    description: 'The Discord username of the bot.',
+  }),
+  displayName: z.string().nullable().meta({
+    description: 'The Discord display name (global name) of the bot, or null if none is set.',
+  }),
+  discriminator: z.string().meta({
+    description: 'The Discord discriminator.',
+  }),
+  avatarUrl: z.string().nullable().meta({
+    description: 'URL of the bot avatar on the Discord CDN, or null if none is set.',
+  }),
+  bannerUrl: z.string().nullable().meta({
+    description: 'URL of the bot banner on the Discord CDN, or null if none is set.',
+  }),
+  accentColor: z.number().int().nullable().meta({
+    description: 'The bot profile accent color as an integer (0xRRGGBB), usable as a fallback when no banner is set.',
+  }),
+});
+
 export const GetBotSchema = z.object({
   id: z.string().meta({
     description: 'The bot ID.',
@@ -31,6 +52,10 @@ export const GetBotSchema = z.object({
   }),
   dockerImage: GetBotDockerImageSchema.meta({
     description: 'The Docker image configuration associated with the bot.',
+  }),
+  discord: GetBotDiscordSchema.nullable().optional().meta({
+    description:
+      "The bot's Discord profile.",
   }),
 });
 

--- a/packages/backend/src/bot/dto/get-bot.dto.ts
+++ b/packages/backend/src/bot/dto/get-bot.dto.ts
@@ -54,8 +54,7 @@ export const GetBotSchema = z.object({
     description: 'The Docker image configuration associated with the bot.',
   }),
   discord: GetBotDiscordSchema.nullable().optional().meta({
-    description:
-      "The bot's Discord profile.",
+    description: "The bot's Discord profile.",
   }),
 });
 

--- a/packages/backend/src/discord/discord.module.ts
+++ b/packages/backend/src/discord/discord.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { DiscordService } from './discord.service.js';
+
+@Module({
+  providers: [DiscordService],
+  exports: [DiscordService],
+})
+export class DiscordModule {}

--- a/packages/backend/src/discord/discord.service.spec.ts
+++ b/packages/backend/src/discord/discord.service.spec.ts
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals';
+import { HttpException, HttpStatus, UnauthorizedException } from '@nestjs/common';
+
+import { DiscordService } from './discord.service.js';
+
+const TOKEN = 'a-bot-token';
+const BOT_ID = '1352006130926096504';
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: () => Promise.resolve(body),
+  }) as Response;
+
+describe('DiscordService', () => {
+  const service = new DiscordService();
+  const originalFetch = globalThis.fetch;
+  const fetchMock = jest.fn<typeof fetch>();
+
+  beforeAll(() => {
+    globalThis.fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  describe('getGatewayBot', () => {
+    it('returns the recommended shard count', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { shards: 4 }));
+
+      await expect(service.getGatewayBot(TOKEN)).resolves.toEqual({ shards: 4 });
+    });
+
+    it('throws UnauthorizedException on a 401 (invalid token)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(401, {}));
+
+      await expect(service.getGatewayBot(TOKEN)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws a 424 when the Discord API errors', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(500, {}));
+
+      await expect(service.getGatewayBot(TOKEN)).rejects.toMatchObject({ status: HttpStatus.FAILED_DEPENDENCY });
+    });
+
+    it('throws a 424 when the shard count is missing', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
+
+      await expect(service.getGatewayBot(TOKEN)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('maps a network failure / timeout to a 424', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('timeout'));
+
+      await expect(service.getGatewayBot(TOKEN)).rejects.toMatchObject({ status: HttpStatus.FAILED_DEPENDENCY });
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    it('maps the user and builds CDN URLs (png avatar, animated gif banner)', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: BOT_ID,
+          username: 'HallMaster',
+          global_name: 'HallMaster Bot',
+          discriminator: '0',
+          avatar: 'abc123',
+          banner: 'a_def456',
+          accent_color: 5793266,
+        }),
+      );
+
+      await expect(service.getCurrentUser(TOKEN)).resolves.toEqual({
+        name: 'HallMaster',
+        displayName: 'HallMaster Bot',
+        discriminator: '0',
+        avatarUrl: `https://cdn.discordapp.com/avatars/${BOT_ID}/abc123.png`,
+        bannerUrl: `https://cdn.discordapp.com/banners/${BOT_ID}/a_def456.gif`,
+        accentColor: 5793266,
+      });
+    });
+
+    it('returns null URLs, displayName and accentColor when the bot has none', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: BOT_ID,
+          username: 'HallMaster',
+          global_name: null,
+          discriminator: '0001',
+          avatar: null,
+          banner: null,
+          accent_color: null,
+        }),
+      );
+
+      await expect(service.getCurrentUser(TOKEN)).resolves.toEqual({
+        name: 'HallMaster',
+        displayName: null,
+        discriminator: '0001',
+        avatarUrl: null,
+        bannerUrl: null,
+        accentColor: null,
+      });
+    });
+  });
+});

--- a/packages/backend/src/discord/discord.service.ts
+++ b/packages/backend/src/discord/discord.service.ts
@@ -1,0 +1,89 @@
+import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
+
+const DISCORD_API_VERSION = 'v10';
+const DISCORD_API_BASE_URL = `https://discord.com/api/${DISCORD_API_VERSION}`;
+const DISCORD_CDN_BASE_URL = 'https://cdn.discordapp.com';
+const DISCORD_REQUEST_TIMEOUT_MS = 10_000;
+
+export interface DiscordGatewayBot {
+  shards: number;
+}
+
+export interface DiscordProfile {
+  name: string;
+  displayName: string | null;
+  discriminator: string;
+  avatarUrl: string | null;
+  bannerUrl: string | null;
+  accentColor: number | null;
+}
+
+interface DiscordUser {
+  id: string;
+  username: string;
+  global_name: string | null;
+  discriminator: string;
+  avatar: string | null;
+  banner: string | null;
+  accent_color: number | null;
+}
+
+@Injectable()
+export class DiscordService {
+  private async request<T>(path: string, token: string): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(`${DISCORD_API_BASE_URL}${path}`, {
+        headers: { Authorization: `Bot ${token}` },
+        signal: AbortSignal.timeout(DISCORD_REQUEST_TIMEOUT_MS),
+      });
+    } catch {
+      throw new HttpException('The Discord API is unreachable or timed out.', HttpStatus.FAILED_DEPENDENCY);
+    }
+
+    if (response.status === 401) {
+      throw new UnauthorizedException('Invalid Discord bot token.');
+    }
+
+    if (!response.ok) {
+      throw new HttpException(
+        `Discord API returned ${response.status}: ${response.statusText}`,
+        HttpStatus.FAILED_DEPENDENCY,
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  async getGatewayBot(token: string): Promise<DiscordGatewayBot> {
+    const data = await this.request<{ shards?: number }>('/gateway/bot', token);
+
+    if (typeof data.shards !== 'number') {
+      throw new HttpException('Got an invalid response from the Discord API.', HttpStatus.FAILED_DEPENDENCY);
+    }
+
+    return { shards: data.shards };
+  }
+
+  async getCurrentUser(token: string): Promise<DiscordProfile> {
+    const user = await this.request<DiscordUser>('/users/@me', token);
+
+    return {
+      name: user.username,
+      displayName: user.global_name ?? null,
+      discriminator: user.discriminator,
+      avatarUrl: DiscordService.buildCdnUrl('avatars', user.id, user.avatar),
+      bannerUrl: DiscordService.buildCdnUrl('banners', user.id, user.banner),
+      accentColor: user.accent_color ?? null,
+    };
+  }
+
+  private static buildCdnUrl(kind: 'avatars' | 'banners', id: string, hash: string | null): string | null {
+    if (!hash) {
+      return null;
+    }
+
+    const extension = hash.startsWith('a_') ? 'gif' : 'png';
+    return `${DISCORD_CDN_BASE_URL}/${kind}/${id}/${hash}.${extension}`;
+  }
+}

--- a/packages/backend/src/discord/discord.service.ts
+++ b/packages/backend/src/discord/discord.service.ts
@@ -1,9 +1,24 @@
 import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
+import { z } from 'zod';
 
 const DISCORD_API_VERSION = 'v10';
 const DISCORD_API_BASE_URL = `https://discord.com/api/${DISCORD_API_VERSION}`;
 const DISCORD_CDN_BASE_URL = 'https://cdn.discordapp.com';
 const DISCORD_REQUEST_TIMEOUT_MS = 10_000;
+
+const DiscordGatewayBotSchema = z.object({
+  shards: z.number().int().nonnegative(),
+});
+
+const DiscordUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  global_name: z.string().nullish(),
+  discriminator: z.string(),
+  avatar: z.string().nullish(),
+  banner: z.string().nullish(),
+  accent_color: z.number().int().nullish(),
+});
 
 export interface DiscordGatewayBot {
   shards: number;
@@ -18,19 +33,9 @@ export interface DiscordProfile {
   accentColor: number | null;
 }
 
-interface DiscordUser {
-  id: string;
-  username: string;
-  global_name: string | null;
-  discriminator: string;
-  avatar: string | null;
-  banner: string | null;
-  accent_color: number | null;
-}
-
 @Injectable()
 export class DiscordService {
-  private async request<T>(path: string, token: string): Promise<T> {
+  private async request<S extends z.ZodType>(path: string, token: string, schema: S): Promise<z.infer<S>> {
     let response: Response;
     try {
       response = await fetch(`${DISCORD_API_BASE_URL}${path}`, {
@@ -52,28 +57,28 @@ export class DiscordService {
       );
     }
 
-    return (await response.json()) as T;
+    const payload: unknown = await response.json().catch(() => undefined);
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      throw new HttpException('The Discord API returned an unexpected response.', HttpStatus.FAILED_DEPENDENCY);
+    }
+
+    return parsed.data;
   }
 
   async getGatewayBot(token: string): Promise<DiscordGatewayBot> {
-    const data = await this.request<{ shards?: number }>('/gateway/bot', token);
-
-    if (typeof data.shards !== 'number') {
-      throw new HttpException('Got an invalid response from the Discord API.', HttpStatus.FAILED_DEPENDENCY);
-    }
-
-    return { shards: data.shards };
+    return await this.request('/gateway/bot', token, DiscordGatewayBotSchema);
   }
 
   async getCurrentUser(token: string): Promise<DiscordProfile> {
-    const user = await this.request<DiscordUser>('/users/@me', token);
+    const user = await this.request('/users/@me', token, DiscordUserSchema);
 
     return {
       name: user.username,
       displayName: user.global_name ?? null,
       discriminator: user.discriminator,
-      avatarUrl: DiscordService.buildCdnUrl('avatars', user.id, user.avatar),
-      bannerUrl: DiscordService.buildCdnUrl('banners', user.id, user.banner),
+      avatarUrl: DiscordService.buildCdnUrl('avatars', user.id, user.avatar ?? null),
+      bannerUrl: DiscordService.buildCdnUrl('banners', user.id, user.banner ?? null),
       accentColor: user.accent_color ?? null,
     };
   }


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Adds the bot's live Discord profile to GET /bot, and extracts all Discord API calls into a dedicated service.

---

## Context / Motivation

Explain **why** this change is needed:
For dynamic UI integration

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
