### PR TITLE
fix(backend): clamp negative CPU delta to 0 in container stats

### DIFF
--- a/packages/backend/src/docker/docker.service.spec.ts
+++ b/packages/backend/src/docker/docker.service.spec.ts
@@ -1,4 +1,4 @@
-import { DockerAPIHttpError, DockerSocket } from '@hallmaster/docker.js';
+import { DockerAPIHttpError, DockerSocket, type DockerContainerStats } from '@hallmaster/docker.js';
 import type { Bot, Cluster } from '@hallmaster/prisma-client';
 import { ConfigService } from '@nestjs/config';
 import type { TestingModule } from '@nestjs/testing';
@@ -161,6 +161,45 @@ describe('DockerService', () => {
 
       expect(status).toBe('RUNNING');
       expect(prismaService.cluster.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getContainerStats CPU percentage', () => {
+    const buildStats = (cpuTotal: number, precpuTotal: number) =>
+      ({
+        cpu_stats: {
+          cpu_usage: { total_usage: cpuTotal, percpu_usage: [0], usage_in_kernelmode: 0, usage_in_usermode: 0 },
+          system_cpu_usage: 2_000_000,
+          online_cpus: 1,
+          throttling_data: { periods: 0, throttled_periods: 0, throttled_time: 0 },
+        },
+        precpu_stats: {
+          cpu_usage: { total_usage: precpuTotal, percpu_usage: [0], usage_in_kernelmode: 0, usage_in_usermode: 0 },
+          system_cpu_usage: 1_000_000,
+          online_cpus: 1,
+          throttling_data: { periods: 0, throttled_periods: 0, throttled_time: 0 },
+        },
+        pids_stats: { current: 1, limit: 10 },
+        memory_stats: { usage: 100, limit: 1000, stats: {} },
+        blkio_stats: { io_service_bytes_recursive: [] },
+        networks: {},
+      }) as unknown as DockerContainerStats;
+
+    it('clamps CPU to 0 when the delta is negative (counter reset on restart)', async () => {
+      dockerSocket.apiCall.mockResolvedValueOnce(buildStats(100, 1000));
+
+      const stats = await service.getContainerStats('container-1');
+
+      expect(stats.cpuPercentage).toBe(0);
+    });
+
+    it('computes the CPU percentage from a positive delta', async () => {
+      dockerSocket.apiCall.mockResolvedValueOnce(buildStats(1500, 1000));
+
+      const stats = await service.getContainerStats('container-1');
+
+      // cpuDelta 500 / systemDelta 1_000_000 * 1 online cpu * 100
+      expect(stats.cpuPercentage).toBeCloseTo(0.05);
     });
   });
 });

--- a/packages/backend/src/docker/docker.service.ts
+++ b/packages/backend/src/docker/docker.service.ts
@@ -449,7 +449,7 @@ export class DockerService {
 
     const onlineCPUs = stats.cpu_stats.online_cpus ?? stats.cpu_stats.cpu_usage.percpu_usage?.length ?? 1;
 
-    const cpuPercentage = systemDelta > 0 ? (cpuDelta / systemDelta) * onlineCPUs * 100 : 0;
+    const cpuPercentage = systemDelta > 0 && cpuDelta > 0 ? (cpuDelta / systemDelta) * onlineCPUs * 100 : 0;
 
     const processesUsage = stats.pids_stats.current;
     const processesPercentage = (processesUsage / stats.pids_stats.limit) * 100;


### PR DESCRIPTION
## Description

Briefly describe **what this PR does** :
Fixes this on cluster reload
<img width="506" height="218" alt="image" src="https://github.com/user-attachments/assets/21d991b6-9f58-47c5-9517-4ca68846341a" />

---

## Context / Motivation

Explain **why** this change is needed:
<!-- What problem does it solve? What is the motivation or background? -->

---

## Related Links

<!-- Related Issue: #123
- Related Docs: (optional link)
- Discussion: (optional link) -->

---

## Screenshots (if applicable)

<!-- Add before/after screenshots, UI previews, etc. -->

---

## Checklist

* [x] My code follows the project's coding style
* [x] Tests pass locally
* [x] I added/updated relevant tests
* [ ] I updated documentation (if needed)
* [x] This PR is ready for review

---

## Additional Notes

<!-- Add any context or considerations for reviewers (edge cases, dependencies, performance concerns, etc.) -->
